### PR TITLE
Feat/enemy tracking rewrite

### DIFF
--- a/GTFOHax/globals.cpp
+++ b/GTFOHax/globals.cpp
@@ -23,9 +23,9 @@ namespace G {
     std::mutex worldTerminalsMtx;
     std::mutex worldHSUMtx;
     std::mutex worldBulkheadMtx;
-    std::mutex enemyVecMtx;
     std::mutex imguiMtx;
     std::mutex enemyAimMtx;
+    std::mutex matrixMtx;
 
     bool initialized = false;
     bool showMenu = true;
@@ -40,9 +40,10 @@ namespace G {
     app::Matrix4x4 w2CamMatrix;
     app::Matrix4x4 projMatrix;
     app::Matrix4x4 viewMatrix;
-    app::PlayerAgent* localPlayer = NULL;
-    int32_t screenHeight = NULL;
-    int32_t screenWidth = NULL;
+    app::Matrix4x4 renderViewMatrix;
+    app::PlayerAgent* localPlayer;
+    int32_t screenHeight;
+    int32_t screenWidth;
 
     ImFont* defaultFont;
     ImFont* espFont;

--- a/GTFOHax/globals.h
+++ b/GTFOHax/globals.h
@@ -42,9 +42,9 @@ namespace G {
     extern std::mutex worldTerminalsMtx;
     extern std::mutex worldHSUMtx;
     extern std::mutex worldBulkheadMtx;
-    extern std::mutex enemyVecMtx;
     extern std::mutex imguiMtx;
     extern std::mutex enemyAimMtx;
+    extern std::mutex matrixMtx;
 
     extern bool initialized;
     extern bool showMenu;
@@ -59,6 +59,7 @@ namespace G {
     extern app::Matrix4x4 w2CamMatrix;
     extern app::Matrix4x4 projMatrix;
     extern app::Matrix4x4 viewMatrix;
+    extern app::Matrix4x4 renderViewMatrix;
     extern app::PlayerAgent* localPlayer;
     extern int32_t screenHeight;
     extern int32_t screenWidth;

--- a/GTFOHax/hacks/aimbot.cpp
+++ b/GTFOHax/hacks/aimbot.cpp
@@ -176,7 +176,7 @@ namespace Aimbot
             
             // Validate that targetEnemy still exists in the enemy list
             bool enemyStillValid = false;
-            auto aimSnap = Enemy::enemiesAimbot.load();
+            auto aimSnap = Enemy::enemiesReady.load();
             if (aimSnap)
             {
                 for (const auto& enemyInfo : *aimSnap)
@@ -247,7 +247,7 @@ namespace Aimbot
         app::LocalPlayerAgent* localPlayerAgent = reinterpret_cast<app::LocalPlayerAgent*>(G::localPlayer);
         app::Vector3 playerForwardVec = app::FPSCamera_get_Forward(localPlayerAgent->fields.m_FPSCamera, NULL);
 
-        auto aimSnap = Enemy::enemiesAimbot.load();
+        auto aimSnap = Enemy::enemiesReady.load();
         if (!aimSnap || aimSnap->empty())
         {
             isSilentAiming = false;

--- a/GTFOHax/hacks/aimbot.cpp
+++ b/GTFOHax/hacks/aimbot.cpp
@@ -74,11 +74,11 @@ namespace Aimbot
                 
                 for (const auto& boneType : boneGroup)
                 {
-                    auto it = ghost.skeletonPositions.find(boneType);
-                    if (it == ghost.skeletonPositions.end())
+                    int idx = static_cast<int>(boneType);
+                    if (idx < 0 || idx >= 64 || !ghost.hasBone[idx])
                         continue;
                         
-                    app::Vector3 curPos = it->second;
+                    app::Vector3 curPos = ghost.skeletonPositions[idx];
                     
                     if (hasPrev && !(prevPos.x == 0.0f && prevPos.y == 0.0f && prevPos.z == 0.0f))
                     {
@@ -176,12 +176,16 @@ namespace Aimbot
             
             // Validate that targetEnemy still exists in the enemy list
             bool enemyStillValid = false;
-            for (const auto& enemyInfo : Enemy::enemiesAimbot)
+            auto aimSnap = Enemy::enemiesAimbot.load();
+            if (aimSnap)
             {
-                if (enemyInfo->enemyAgent == targetEnemy)
+                for (const auto& enemyInfo : *aimSnap)
                 {
-                    enemyStillValid = true;
-                    break;
+                    if (enemyInfo->enemyAgent == targetEnemy)
+                    {
+                        enemyStillValid = true;
+                        break;
+                    }
                 }
             }
             
@@ -243,17 +247,27 @@ namespace Aimbot
         app::LocalPlayerAgent* localPlayerAgent = reinterpret_cast<app::LocalPlayerAgent*>(G::localPlayer);
         app::Vector3 playerForwardVec = app::FPSCamera_get_Forward(localPlayerAgent->fields.m_FPSCamera, NULL);
 
-        G::enemyAimMtx.lock();
-        std::vector<std::shared_ptr<Enemy::EnemyInfo>> enemies = Enemy::enemiesAimbot;
-        G::enemyAimMtx.unlock();
+        auto aimSnap = Enemy::enemiesAimbot.load();
+        if (!aimSnap || aimSnap->empty())
+        {
+            isSilentAiming = false;
+            targetEnemy = nullptr;
+            targetLimb = nullptr;
+            return;
+        }
+
+        // Use a temporary vector of pointers for sorting
+        static std::vector<Enemy::EnemyInfo*> enemies;
+        enemies.clear();
+        enemies.reserve(aimSnap->size());
+        for (auto& enemy : *aimSnap)
+            enemies.push_back(enemy.get());
         
-        // TODO: Time this? Is it worth to sort and then loop again for convenience
-        // or should it all be done in a single loop?
         switch (settings.priority)
         {
             case Health:
             {
-                std::sort(enemies.begin(), enemies.end(), [](const std::shared_ptr<Enemy::EnemyInfo> lhs, const std::shared_ptr<Enemy::EnemyInfo> rhs) {
+                std::sort(enemies.begin(), enemies.end(), [](Enemy::EnemyInfo* lhs, Enemy::EnemyInfo* rhs) {
                     auto enemyDamageLhs = reinterpret_cast<app::Dam_SyncedDamageBase*>(lhs->enemyAgent->fields.Damage);
                     auto enemyDamageRhs = reinterpret_cast<app::Dam_SyncedDamageBase*>(rhs->enemyAgent->fields.Damage);
                     return enemyDamageLhs->fields._Health_k__BackingField < enemyDamageRhs->fields._Health_k__BackingField;
@@ -262,19 +276,21 @@ namespace Aimbot
             }
             case Distance:
             {
-                std::sort(enemies.begin(), enemies.end(), [](const std::shared_ptr<Enemy::EnemyInfo> lhs, const std::shared_ptr<Enemy::EnemyInfo> rhs) {
+                std::sort(enemies.begin(), enemies.end(), [](Enemy::EnemyInfo* lhs, Enemy::EnemyInfo* rhs) {
                     return lhs->distance < rhs->distance;
                     });
                 break;
             }
             case FOV:
             {
-                std::sort(enemies.begin(), enemies.end(), [localEyePos, playerForwardVec](const std::shared_ptr<Enemy::EnemyInfo> lhs, const std::shared_ptr<Enemy::EnemyInfo> rhs) {
-                    app::Vector3 lhsPos = lhs->useFallback ? lhs->fallbackBone.position : lhs->skeletonBones.at(app::HumanBodyBones__Enum::Head).position;
-                    app::Vector3 lhsVec = Math::Vector3Sub(lhsPos, localEyePos);
+                std::sort(enemies.begin(), enemies.end(), [localEyePos, playerForwardVec](Enemy::EnemyInfo* lhs, Enemy::EnemyInfo* rhs) {
+                    const Enemy::Bone* lhsHead = lhs->useFallback ? &lhs->fallbackBone : lhs->getBone(app::HumanBodyBones__Enum::Head);
+                    const Enemy::Bone* rhsHead = rhs->useFallback ? &rhs->fallbackBone : rhs->getBone(app::HumanBodyBones__Enum::Head);
+                    
+                    if (!lhsHead || !rhsHead) return false;
 
-                    app::Vector3 rhsPos = rhs->useFallback ? rhs->fallbackBone.position : rhs->skeletonBones.at(app::HumanBodyBones__Enum::Head).position;
-                    app::Vector3 rhsVec = Math::Vector3Sub(rhsPos, localEyePos);
+                    app::Vector3 lhsVec = Math::Vector3Sub(lhsHead->position, localEyePos);
+                    app::Vector3 rhsVec = Math::Vector3Sub(rhsHead->position, localEyePos);
 
                     return app::Vector3_Angle(playerForwardVec, lhsVec, NULL) < app::Vector3_Angle(playerForwardVec, rhsVec, NULL);
                     });
@@ -283,9 +299,8 @@ namespace Aimbot
         }
 
         bool foundEnemy = false;
-        for (auto it = enemies.begin(); it != enemies.end(); ++it)
+        for (auto enemyInfo : enemies)
         {
-            Enemy::EnemyInfo* enemyInfo = (*it).get();
             if ((settings.visibleOnly && !enemyInfo->visible)
                 || (settings.maxDistance < enemyInfo->distance))
                 continue;
@@ -296,10 +311,11 @@ namespace Aimbot
 
             Enemy::Bone bestBone;
             bool foundBone = false;
-            if (!enemyInfo->damageableBones.empty())
+            if (enemyInfo->damageableBoneCount > 0)
             {
-                for (Enemy::Bone& bone : enemyInfo->damageableBones)
+                for (int bi = 0; bi < enemyInfo->damageableBoneCount; bi++)
                 {
+                    Enemy::Bone& bone = enemyInfo->damageableBones[bi];
                     if (settings.visibleOnly && !bone.visible)
                         continue;
                     if (!settings.aimAtArmor && bone.limbType == app::eLimbDamageType__Enum::Armor)
@@ -310,14 +326,9 @@ namespace Aimbot
                     if (angle > (settings.aimFov / 2))
                         continue;
 
-                    if (enemyInfo->skeletonBones.contains(app::HumanBodyBones__Enum::Head))
-                    {
-                        // Destroyed head bone can't be shot at. Make sure this isn't that
-                        Enemy::Bone headBone = enemyInfo->skeletonBones[app::HumanBodyBones__Enum::Head]; // TODO: Fix map issue
-                        if (headBone.destroyed && Math::Vector3Eq(headBone.position, bone.position))
-                            continue;
-                    }
-
+                    const Enemy::Bone* headBone = enemyInfo->getBone(app::HumanBodyBones__Enum::Head);
+                    if (headBone && headBone->destroyed && Math::Vector3Eq(headBone->position, bone.position))
+                        continue;
 
                     if (!foundBone)
                     {
@@ -325,22 +336,19 @@ namespace Aimbot
                         foundBone = true;
                         continue;
                     }
-                    
+
                     if ((bestBone.limbType == app::eLimbDamageType__Enum::Armor && (bone.limbType == app::eLimbDamageType__Enum::Normal || bone.limbType == app::eLimbDamageType__Enum::Weakspot))
                         || (bestBone.limbType == app::eLimbDamageType__Enum::Normal && bone.limbType == app::eLimbDamageType__Enum::Weakspot))
-                    {
-                        // Current bone limbtype is better
-                        bestBone = bone;
-                        continue;
-                    }
-                    
-                    if (bestBone.limbType == bone.limbType &&
-                        (bone.health > bestBone.health))
                     {
                         bestBone = bone;
                         continue;
                     }
 
+                    if (bestBone.limbType == bone.limbType && bone.health > bestBone.health)
+                    {
+                        bestBone = bone;
+                        continue;
+                    }
                 }
             }
             else if (enemyInfo->useFallback && !(settings.visibleOnly && !enemyInfo->fallbackBone.visible))

--- a/GTFOHax/hacks/aimbot.h
+++ b/GTFOHax/hacks/aimbot.h
@@ -11,16 +11,23 @@ namespace Aimbot
     // Hit ghost effect - shows a fading skeleton at hit location
     struct HitGhost
     {
-        std::map<app::HumanBodyBones__Enum, app::Vector3> skeletonPositions;  // Snapshot of skeleton at hit time
+        app::Vector3 skeletonPositions[64];
+        bool hasBone[64];
         std::chrono::steady_clock::time_point hitTime;  // When the hit occurred
         float duration;  // How long to display (seconds)
         
         HitGhost(const std::map<app::HumanBodyBones__Enum, Enemy::Bone>& bones, float duration = 0.3f)
             : hitTime(std::chrono::steady_clock::now()), duration(duration)
         {
+            memset(hasBone, 0, sizeof(hasBone));
             for (const auto& [boneType, bone] : bones)
             {
-                skeletonPositions[boneType] = bone.position;
+                int idx = static_cast<int>(boneType);
+                if (idx >= 0 && idx < 64)
+                {
+                    skeletonPositions[idx] = bone.position;
+                    hasBone[idx] = true;
+                }
             }
         }
         

--- a/GTFOHax/hacks/enemy.cpp
+++ b/GTFOHax/hacks/enemy.cpp
@@ -1,10 +1,11 @@
 #include "enemy.h"
 #include <cmath>
 #include <iostream>
-#include <unordered_set>
 #include <unordered_map>
 #include <chrono>
 #include <format>
+#include <thread>
+#include <mutex>
 #include <helpers.h>
 #include "aimbot.h"
 #include "esp.h"
@@ -13,12 +14,11 @@
 namespace Enemy
 {
     std::atomic<std::shared_ptr<EnemyVec>> enemies;
-    std::atomic<std::shared_ptr<EnemyVec>> enemiesAimbot;
+    std::atomic<std::shared_ptr<EnemyVec>> enemiesReady;
     std::map<std::string, int> enemyIDs;
     std::vector<std::string> enemyNames;
 
-    std::map<app::EnemyAgent*, EnemyPositionHistory> enemyPositionHistory;
-    std::mutex enemyPositionHistoryMtx;
+    std::unordered_map<app::EnemyAgent*, EnemyPositionHistory> enemyPositionHistory;
 
     struct BoneLineCastCache
     {
@@ -30,22 +30,88 @@ namespace Enemy
 
     struct EnemyCacheEntry
     {
-        BoneLineCastCache boneCache[64];
-        app::Transform*   boneTransforms[64];
-        bool              boneTransformCached[64];
-        BoneLineCastCache fallbackCache;
-        std::string       enemyName;
+        BoneLineCastCache         boneCache[64];
+        app::Transform*           boneTransforms[64];
+        bool                      boneTransformCached[64];
+        app::Dam_EnemyDamageLimb* boneLimb[64];
+        bool                      boneLimbResolved[64];
+        BoneLineCastCache         fallbackCache;
+        std::string               enemyName;
+        uint32_t                  lastTouchFrame;
+
+        struct CachedLimb {
+            app::Dam_EnemyDamageLimb* ptr       = nullptr;
+            app::Transform*           transform  = nullptr;
+        };
+        CachedLimb cachedLimbs[32];
+        int        cachedLimbCount  = 0;
+        bool       cachedLimbsReady = false;
 
         EnemyCacheEntry()
         {
             memset(boneTransforms, 0, sizeof(boneTransforms));
             memset(boneTransformCached, 0, sizeof(boneTransformCached));
+            memset(boneLimb, 0, sizeof(boneLimb));
+            memset(boneLimbResolved, 0, sizeof(boneLimbResolved));
+            memset(cachedLimbs, 0, sizeof(cachedLimbs));
+            lastTouchFrame = 0;
         }
     };
 
     static std::unordered_map<app::EnemyAgent*, EnemyCacheEntry> linecastCache;
+
+    struct GameVisCache
+    {
+        BoneLineCastCache bones[64];
+        BoneLineCastCache fallback;
+    };
+    static std::unordered_map<app::EnemyAgent*, GameVisCache> g_gameVisCache;
     static constexpr float BONE_MOVE_THRESHOLD_SQ = 0.01f * 0.01f; // 1cm
     static constexpr float EYE_MOVE_THRESHOLD_SQ  = 0.01f * 0.01f; // 1cm
+
+    struct EnemyInfoPool
+    {
+        std::vector<std::unique_ptr<EnemyInfo>> slots;
+        std::vector<EnemyInfo*>                 freeList;
+        std::mutex                              mtx;
+
+        std::shared_ptr<EnemyInfo> acquire()
+        {
+            EnemyInfo* ptr;
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                if (!freeList.empty())
+                {
+                    ptr = freeList.back();
+                    freeList.pop_back();
+                }
+                else
+                {
+                    slots.push_back(std::make_unique<EnemyInfo>());
+                    ptr = slots.back().get();
+                }
+            }
+            ptr->reset();
+            return std::shared_ptr<EnemyInfo>(ptr, [this](EnemyInfo* p) {
+                std::lock_guard<std::mutex> lock(mtx);
+                freeList.push_back(p);
+            });
+        }
+    };
+    static EnemyInfoPool g_enemyInfoPool;
+
+    static std::thread        g_refreshThread;
+    static std::atomic<bool>  g_refreshRunning{false};
+    static std::mutex         g_positionHistoryMtx;
+
+    static int      g_maskDefault    = 0;
+    static bool     g_maskResolved   = false;
+    static uint32_t g_refreshFrame   = 0;
+
+    // Lazy cleanup: only drop a cache entry after we haven't touched it for this many
+    // successive refreshes. At the 60 Hz throttle below, 600 ≈ 10 seconds.
+    static constexpr uint32_t CACHE_STALE_FRAMES   = 600;
+    static constexpr uint32_t CACHE_SWEEP_INTERVAL = 120;
 
     static constexpr int PERF_LOG_INTERVAL = 120;
 
@@ -53,33 +119,67 @@ namespace Enemy
     {
         int    frames      = 0;
         double totalUs     = 0.0;
+        double loopUs      = 0.0;
+        double sweepUs     = 0.0;
+        double publishUs   = 0.0;
+        double bonePosUs   = 0.0;   // Transform_get_position_Injected
+        double limbPosUs   = 0.0;   // Dam_EnemyDamageLimb_get_DamageTargetPos
+        double animUs      = 0.0;   // Animator_GetBoneTransform
+        double visUs       = 0.0;   // isBoneVisible_cached (incl. raycasts)
         double minUs       = 1e9;
         double maxUs       = 0.0;
         int    raycasts    = 0;
         int    cacheHits   = 0;
         int    animCalls   = 0;
+        int    enemyCount  = 0;
+        int    staleCount  = 0;
 
-        void record(double frameUs, int frameCasts, int frameHits, int frameAnimCalls)
+        void record(double frameUs, double frameLoopUs, double frameSweepUs, double framePublishUs,
+                    double frameBonePosUs, double frameLimbPosUs, double frameAnimUs, double frameVisUs,
+                    int frameCasts, int frameHits, int frameAnimCalls, int frameEnemies, int frameStale)
         {
             ++frames;
             totalUs    += frameUs;
+            loopUs     += frameLoopUs;
+            sweepUs    += frameSweepUs;
+            publishUs  += framePublishUs;
+            bonePosUs  += frameBonePosUs;
+            limbPosUs  += frameLimbPosUs;
+            animUs     += frameAnimUs;
+            visUs      += frameVisUs;
             if (frameUs < minUs) minUs = frameUs;
             if (frameUs > maxUs) maxUs = frameUs;
             raycasts   += frameCasts;
             cacheHits  += frameHits;
             animCalls  += frameAnimCalls;
+            enemyCount += frameEnemies;
+            staleCount += frameStale;
         }
 
         void logAndReset()
         {
             if (frames == 0) return;
-            double avgUs    = totalUs / frames;
-            int    totalOps = raycasts + cacheHits;
-            float  hitRate  = totalOps > 0 ? 100.f * cacheHits / totalOps : 0.f;
+            double avgUs        = totalUs   / frames;
+            double avgLoopUs    = loopUs    / frames;
+            double avgSweepUs   = sweepUs   / frames;
+            double avgPublishUs = publishUs / frames;
+            double avgBonePosUs = bonePosUs / frames;
+            double avgLimbPosUs = limbPosUs / frames;
+            double avgAnimUs    = animUs    / frames;
+            double avgVisUs     = visUs     / frames;
+            int    totalOps     = raycasts + cacheHits;
+            float  hitRate      = totalOps > 0 ? 100.f * cacheHits / totalOps : 0.f;
+            int   totalProcessed = enemyCount + staleCount;
+            float stalePct       = totalProcessed > 0 ? 100.f * staleCount / totalProcessed : 0.f;
             il2cppi_log_write(std::format(
                 "[EnemyPerf] frames={} avg={:.1f}us min={:.1f}us max={:.1f}us | "
-                "animCalls={} raycasts={} cacheHits={} hitRate={:.1f}%",
+                "loop={:.1f}us sweep={:.1f}us publish={:.1f}us | "
+                "bones+vis={:.1f}us limbs={:.1f}us anim={:.1f}us | "
+                "enemyCount={} stale={:.0f} stalePct={:.1f}% animCalls={} raycasts={} cacheHits={} hitRate={:.1f}%",
                 frames, avgUs, minUs, maxUs,
+                avgLoopUs, avgSweepUs, avgPublishUs,
+                avgBonePosUs, avgLimbPosUs, avgAnimUs,
+                enemyCount / frames, (double)staleCount / frames, stalePct,
                 animCalls, raycasts, cacheHits, hitRate));
             *this = PerfStats{};
         }
@@ -90,7 +190,7 @@ namespace Enemy
     {
         app::Vector3 zeroVec = {0.0f, 0.0f, 0.0f};
         if (enemy == nullptr) return zeroVec;
-        std::lock_guard<std::mutex> lock(enemyPositionHistoryMtx);
+        std::lock_guard<std::mutex> lock(g_positionHistoryMtx);
         auto it = enemyPositionHistory.find(enemy);
         if (it != enemyPositionHistory.end() && it->second.hasValidDirection)
             return it->second.movementDirection;
@@ -121,9 +221,12 @@ namespace Enemy
         }
         
         ++s_frameCasts;
-        cache.lastVisible = !app::Physics_Linecast_1(
-            eyePos, bonePos,
-            (*app::LayerManager__TypeInfo)->static_fields->MASK_DEFAULT, NULL);
+        if (!g_maskResolved)
+        {
+            g_maskDefault  = (*app::LayerManager__TypeInfo)->static_fields->MASK_DEFAULT;
+            g_maskResolved = true;
+        }
+        cache.lastVisible = !app::Physics_Linecast_1(eyePos, bonePos, g_maskDefault, NULL);
         cache.lastBonePos      = bonePos;
         cache.lastPlayerEyePos = eyePos;
         cache.valid            = true;
@@ -151,27 +254,39 @@ namespace Enemy
 
     void _RefreshEnemyAgents()
     {
+        if (G::gameQuit)
+            return;
         if (!ESP::enemyESP.toggleKey.isToggled() && !Aimbot::settings.toggleKey.isToggled())
             return;
         if (G::localPlayer == nullptr)
             return;
+
+        static bool mapsReserved = false;
+        if (!mapsReserved) {
+            linecastCache.reserve(512);
+            enemyPositionHistory.reserve(512);
+            mapsReserved = true;
+        }
+
+        ++g_refreshFrame;
 
         auto perfStart  = std::chrono::high_resolution_clock::now();
         s_frameCasts    = 0;
         s_frameHits      = 0;
         s_frameAnimCalls = 0;
 
-        app::Vector3 eyePos = G::localPlayer->fields.m_eyePosition;
+        double frameBonePosUs = 0.0;
+        double frameLimbPosUs = 0.0;
+        double frameAnimUs    = 0.0;
+        double frameVisUs     = 0.0;
+        int    frameEnemyCount = 0;
+
         app::Vector3 localPos = G::localPlayer->fields.m_goodPosition;
-
-        const bool needVisibilityCheck =
-            ESP::enemyESP.visibleSec.show || ESP::enemyESP.nonVisibleSec.show ||
-            (Aimbot::settings.toggleKey.isToggled() && Aimbot::settings.visibleOnly);
-
         static EnemyVec enemiesTemp;
         enemiesTemp.clear();
         if (enemiesTemp.capacity() < 64) enemiesTemp.reserve(128);
 
+        auto loopStart = std::chrono::high_resolution_clock::now();
         auto courseNodesList = (*app::StaticUpdateManager__TypeInfo)->static_fields->courseNodes;
         for (int i = 0; i < courseNodesList->fields._size; i++)
         {
@@ -186,7 +301,7 @@ namespace Enemy
                 if (enemyAgent == NULL || !enemyAgent->fields.m_alive)
                     continue;
 
-                app::Vector3 enemyPos = app::EnemyAgent_get_Position(enemyAgent, NULL);
+                app::Vector3 enemyPos = enemyAgent->fields._.m_position;
                 float dx = enemyPos.x - localPos.x, dy = enemyPos.y - localPos.y, dz = enemyPos.z - localPos.z;
                 float distanceSq = dx*dx + dy*dy + dz*dz;
                 float distance = sqrtf(distanceSq);
@@ -198,7 +313,32 @@ namespace Enemy
                     continue;
                 }
 
+                {
+                    std::lock_guard<std::mutex> lock(g_positionHistoryMtx);
+                    auto hit = enemyPositionHistory.find(enemyAgent);
+                    if (hit != enemyPositionHistory.end())
+                    {
+                        hit->second.previousPosition = hit->second.currentPosition;
+                        hit->second.currentPosition  = enemyPos;
+                        float pdx = enemyPos.x - hit->second.previousPosition.x;
+                        float pdz = enemyPos.z - hit->second.previousPosition.z;
+                        float lenSq = pdx*pdx + pdz*pdz;
+                        if (lenSq > 0.0001f)
+                        {
+                            float len = sqrtf(lenSq);
+                            hit->second.movementDirection = { pdx / len, 0.0f, pdz / len };
+                            hit->second.hasValidDirection = true;
+                        }
+                        hit->second.lastTouchFrame = g_refreshFrame;
+                    }
+                    else
+                    {
+                        enemyPositionHistory[enemyAgent] = { enemyPos, enemyPos, {0.0f, 0.0f, 0.0f}, false, g_refreshFrame };
+                    }
+                }
+
                 auto& cacheEntry = linecastCache[enemyAgent];
+                cacheEntry.lastTouchFrame = g_refreshFrame;
                 if (cacheEntry.enemyName.empty())
                     cacheEntry.enemyName = il2cppi_to_string(
                         app::Object_1_GetName(reinterpret_cast<app::Object_1*>(enemyAgent), NULL));
@@ -207,32 +347,47 @@ namespace Enemy
                 TempLimb tempLimbs[32];
                 int tempLimbCount = 0;
 
-                auto enemyInfo = std::make_shared<EnemyInfo>();
-                enemyInfo->visible = false;
+                auto enemyInfo = g_enemyInfoPool.acquire();
                 enemyInfo->enemyAgent = enemyAgent;
                 enemyInfo->enemyObjectName = cacheEntry.enemyName;
                 enemyInfo->distance = distance;
 
+                ++frameEnemyCount;
+                auto t0enemy = std::chrono::high_resolution_clock::now();
                 auto damageLimbsList = enemyAgent->fields.Damage->fields.DamageLimbs;
                 if (damageLimbsList) {
-                    auto damageLimbs = damageLimbsList->vector;
-                    int limbCount = (std::min)((int)damageLimbsList->max_length, 32);
-                    for (int k = 0; k < limbCount; k++)
-                    {
-                        auto limb = damageLimbs[k];
-                        if (!limb) continue;
-                        auto limbPos = app::Dam_EnemyDamageLimb_get_DamageTargetPos(limb, NULL);
-                        tempLimbs[tempLimbCount++] = { limbPos, limb };
+                    if (!cacheEntry.cachedLimbsReady) {
+                        auto damageLimbs = damageLimbsList->vector;
+                        int limbCount = (std::min)((int)damageLimbsList->max_length, 32);
+                        for (int k = 0; k < limbCount; k++) {
+                            auto limb = damageLimbs[k];
+                            if (!limb) continue;
+                            auto xform = app::Component_1_get_transform(
+                                reinterpret_cast<app::Component_1*>(limb), NULL);
+                            if (!xform) continue;
+                            auto& cl = cacheEntry.cachedLimbs[cacheEntry.cachedLimbCount++];
+                            cl.ptr       = limb;
+                            cl.transform = xform;
+                        }
+                        cacheEntry.cachedLimbsReady = true;
+                    }
+                    for (int k = 0; k < cacheEntry.cachedLimbCount; k++) {
+                        auto& cl = cacheEntry.cachedLimbs[k];
+                        app::Vector3 limbPos;
+                        app::Transform_get_position_Injected(cl.transform, &limbPos, NULL);
+                        tempLimbs[tempLimbCount++] = { limbPos, cl.ptr };
                         Bone& bone = enemyInfo->damageableBones[enemyInfo->damageableBoneCount++];
                         bone.position = limbPos;
                         bone.damageable = true;
-                        bone.destroyed = limb->fields._IsDestroyed_k__BackingField;
-                        bone.limbType = limb->fields.m_type;
-                        bone.health = limb->fields.m_health;
-                        bone.limbPtr = limb;
+                        bone.destroyed = cl.ptr->fields._IsDestroyed_k__BackingField;
+                        bone.limbType  = cl.ptr->fields.m_type;
+                        bone.health    = cl.ptr->fields.m_health;
+                        bone.limbPtr   = cl.ptr;
                     }
                 }
+                frameLimbPosUs += std::chrono::duration<double, std::micro>(std::chrono::high_resolution_clock::now() - t0enemy).count();
 
+                auto t0bones = std::chrono::high_resolution_clock::now();
                 for (auto boneType : Enemy::WantedBones)
                 {
                     int idx = static_cast<int>(boneType);
@@ -247,6 +402,8 @@ namespace Enemy
                     {
                         ++s_frameAnimCalls;
                         boneTransform = app::Animator_GetBoneTransform(enemyAgent->fields.Anim, boneType, NULL);
+                        frameAnimUs += std::chrono::duration<double, std::micro>(std::chrono::high_resolution_clock::now() - t0bones).count();
+                        t0bones = std::chrono::high_resolution_clock::now();
                         cacheEntry.boneTransforms[idx] = boneTransform;
                         cacheEntry.boneTransformCached[idx] = true;
                     }
@@ -255,31 +412,33 @@ namespace Enemy
                     Bone bone;
                     app::Transform_get_position_Injected(boneTransform, &bone.position, NULL);
 
-                    if (needVisibilityCheck)
+                    app::Dam_EnemyDamageLimb* matchedLimb = cacheEntry.boneLimb[idx];
+                    if (matchedLimb == nullptr && !cacheEntry.boneLimbResolved[idx])
                     {
-                        auto& boneCache = cacheEntry.boneCache[idx];
-                        if (isBoneVisible_cached(boneCache, bone.position, eyePos))
-                            enemyInfo->visible = true;
-                        bone.visible = boneCache.lastVisible;
-                    }
-
-                    for (int k = 0; k < tempLimbCount; k++) {
-                        if (tempLimbs[k].pos.x == bone.position.x &&
-                            tempLimbs[k].pos.y == bone.position.y &&
-                            tempLimbs[k].pos.z == bone.position.z) {
-                            auto db = tempLimbs[k].ptr;
-                            bone.damageable = true;
-                            bone.destroyed = db->fields._IsDestroyed_k__BackingField;
-                            bone.limbType = db->fields.m_type;
-                            bone.health = db->fields.m_health;
-                            bone.limbPtr = db;
-                            break;
+                        for (int k = 0; k < tempLimbCount; k++) {
+                            if (tempLimbs[k].pos.x == bone.position.x &&
+                                tempLimbs[k].pos.y == bone.position.y &&
+                                tempLimbs[k].pos.z == bone.position.z) {
+                                matchedLimb = tempLimbs[k].ptr;
+                                cacheEntry.boneLimb[idx] = matchedLimb;
+                                break;
+                            }
                         }
+                        cacheEntry.boneLimbResolved[idx] = true;
+                    }
+                    if (matchedLimb)
+                    {
+                        bone.damageable = true;
+                        bone.destroyed  = matchedLimb->fields._IsDestroyed_k__BackingField;
+                        bone.limbType   = matchedLimb->fields.m_type;
+                        bone.health     = matchedLimb->fields.m_health;
+                        bone.limbPtr    = matchedLimb;
                     }
 
                     enemyInfo->bones[idx] = std::move(bone);
                     enemyInfo->hasBone[idx] = true;
                 }
+                frameBonePosUs += std::chrono::duration<double, std::micro>(std::chrono::high_resolution_clock::now() - t0bones).count();
 
                 bool hasEssentialBones = enemyInfo->hasBone[static_cast<int>(app::HumanBodyBones__Enum::Head)] &&
                                          enemyInfo->hasBone[static_cast<int>(app::HumanBodyBones__Enum::LeftFoot)] &&
@@ -288,65 +447,55 @@ namespace Enemy
                 if (!hasEssentialBones)
                 {
                     enemyInfo->fallbackBone.position = enemyPos;
-                    if (needVisibilityCheck)
-                    {
-                        isBoneVisible_cached(cacheEntry.fallbackCache, enemyInfo->fallbackBone.position, eyePos);
-                        enemyInfo->fallbackBone.visible = cacheEntry.fallbackCache.lastVisible;
-                        enemyInfo->visible = enemyInfo->fallbackBone.visible;
-                    }
                     enemyInfo->useFallback = true;
                 }
 
-                if (isValidDistance(enemyInfo->visible, distance))
+                // Include enemy if it would be valid under *any* visibility state.
+                // Actual visible flag is set by UpdateEnemyVisibility() on the game thread.
+                if (isValidDistance(true, distance) || isValidDistance(false, distance))
                     enemiesTemp.push_back(std::move(enemyInfo));
             }
         }
+        auto loopEnd = std::chrono::high_resolution_clock::now();
 
-        std::unordered_set<app::EnemyAgent*> validEnemies;
+        // Periodic lazy sweep: entries that weren't touched within CACHE_STALE_FRAMES
+        // are evicted. Runs every CACHE_SWEEP_INTERVAL frames,
+        // so the steady-state per-frame cost of cleanup is zero.
+        auto sweepStart = std::chrono::high_resolution_clock::now();
+        if ((g_refreshFrame % CACHE_SWEEP_INTERVAL) == 0)
         {
-            std::lock_guard<std::mutex> lock(enemyPositionHistoryMtx);
-            for (const auto& enemyInfo : enemiesTemp)
+            for (auto it = linecastCache.begin(); it != linecastCache.end(); )
             {
-                app::EnemyAgent* agent = enemyInfo->enemyAgent;
-                validEnemies.insert(agent);
-                app::Vector3 currentPos = app::EnemyAgent_get_Position(agent, NULL);
-                auto it = enemyPositionHistory.find(agent);
-                if (it != enemyPositionHistory.end())
-                {
-                    it->second.previousPosition = it->second.currentPosition;
-                    it->second.currentPosition  = currentPos;
-                    float dx = currentPos.x - it->second.previousPosition.x;
-                    float dz = currentPos.z - it->second.previousPosition.z;
-                    float lenSq = dx*dx + dz*dz;
-                    if (lenSq > 0.0001f)
-                    {
-                        float len = sqrtf(lenSq);
-                        it->second.movementDirection = { dx / len, 0.0f, dz / len };
-                        it->second.hasValidDirection = true;
-                    }
-                }
-                else
-                    enemyPositionHistory[agent] = { currentPos, currentPos, {0,0,0}, false };
-            }
-            for (auto it = enemyPositionHistory.begin(); it != enemyPositionHistory.end(); )
-            {
-                if (validEnemies.find(it->first) == validEnemies.end())
-                    it = enemyPositionHistory.erase(it);
+                if (it->second.lastTouchFrame + CACHE_STALE_FRAMES < g_refreshFrame)
+                    it = linecastCache.erase(it);
                 else
                     ++it;
             }
+            {
+                std::lock_guard<std::mutex> lock(g_positionHistoryMtx);
+                for (auto it = enemyPositionHistory.begin(); it != enemyPositionHistory.end(); )
+                {
+                    if (it->second.lastTouchFrame + CACHE_STALE_FRAMES < g_refreshFrame)
+                        it = enemyPositionHistory.erase(it);
+                    else
+                        ++it;
+                }
+            }
         }
+        auto sweepEnd = std::chrono::high_resolution_clock::now();
 
-        for (auto it = linecastCache.begin(); it != linecastCache.end(); )
-            it = validEnemies.count(it->first) ? std::next(it) : linecastCache.erase(it);
-
-        auto sharedVec = std::make_shared<EnemyVec>(std::move(enemiesTemp));
-        enemies.store(sharedVec);
-        enemiesAimbot.store(std::move(sharedVec));
+        auto publishStart = std::chrono::high_resolution_clock::now();
+        enemies.store(std::make_shared<EnemyVec>(std::move(enemiesTemp)));
+        auto publishEnd = std::chrono::high_resolution_clock::now();
 
         auto perfEnd = std::chrono::high_resolution_clock::now();
-        double frameUs = std::chrono::duration<double, std::micro>(perfEnd - perfStart).count();
-        perf.record(frameUs, s_frameCasts, s_frameHits, s_frameAnimCalls);
+        double frameUs   = std::chrono::duration<double, std::micro>(perfEnd      - perfStart    ).count();
+        double loopMs    = std::chrono::duration<double, std::micro>(loopEnd      - loopStart   ).count();
+        double sweepMs   = std::chrono::duration<double, std::micro>(sweepEnd     - sweepStart  ).count();
+        double publishMs = std::chrono::duration<double, std::micro>(publishEnd   - publishStart).count();
+        perf.record(frameUs, loopMs, sweepMs, publishMs,
+                    frameBonePosUs, frameLimbPosUs, frameAnimUs, 0.0,
+                    s_frameCasts, s_frameHits, s_frameAnimCalls, frameEnemyCount, 0);
         if (perf.frames >= PERF_LOG_INTERVAL)
             perf.logAndReset();
     }
@@ -370,9 +519,82 @@ namespace Enemy
         }
     }
 
+    void UpdateEnemyVisibility()
+    {
+        if (!ESP::enemyESP.toggleKey.isToggled() && !Aimbot::settings.toggleKey.isToggled())
+            return;
+        if (G::localPlayer == nullptr)
+            return;
+
+        const bool needVisibilityCheck =
+            ESP::enemyESP.visibleSec.show || ESP::enemyESP.nonVisibleSec.show ||
+            (Aimbot::settings.toggleKey.isToggled() && Aimbot::settings.visibleOnly);
+        if (!needVisibilityCheck)
+            return;
+
+        static bool reservedOnce = false;
+        if (!reservedOnce)
+        {
+            g_gameVisCache.reserve(512);
+            reservedOnce = true;
+        }
+
+        app::Vector3 eyePos = G::localPlayer->fields.m_eyePosition;
+
+        auto snapshot = enemies.load();
+        if (!snapshot) return;
+
+        for (auto& enemyInfo : *snapshot)
+        {
+            if (!enemyInfo) continue;
+            app::EnemyAgent* agent = enemyInfo->enemyAgent;
+            auto& visCache = g_gameVisCache[agent];
+
+            bool anyVisible = false;
+
+            if (enemyInfo->useFallback)
+            {
+                isBoneVisible_cached(visCache.fallback, enemyInfo->fallbackBone.position, eyePos);
+                enemyInfo->fallbackBone.visible = visCache.fallback.lastVisible;
+                anyVisible = visCache.fallback.lastVisible;
+            }
+            else
+            {
+                for (auto boneType : Enemy::WantedBones)
+                {
+                    int idx = static_cast<int>(boneType);
+                    if (idx < 0 || idx >= 64 || !enemyInfo->hasBone[idx]) continue;
+                    isBoneVisible_cached(visCache.bones[idx], enemyInfo->bones[idx].position, eyePos);
+                    enemyInfo->bones[idx].visible = visCache.bones[idx].lastVisible;
+                    if (visCache.bones[idx].lastVisible) anyVisible = true;
+                }
+            }
+            enemyInfo->visible = anyVisible;
+        }
+
+        enemiesReady.store(snapshot);
+    }
+
     void RefreshEnemyAgents()
     {
-        G::callbacks.push([] { _RefreshEnemyAgents(); });
+        static std::once_flag s_startOnce;
+        std::call_once(s_startOnce, []() {
+            g_refreshRunning.store(true, std::memory_order_relaxed);
+            g_refreshThread = std::thread([]() {
+                while (g_refreshRunning.load(std::memory_order_relaxed))
+                {
+                    _RefreshEnemyAgents();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(4));
+                }
+            });
+        });
+    }
+
+    void StopRefreshThread()
+    {
+        g_refreshRunning.store(false, std::memory_order_relaxed);
+        if (g_refreshThread.joinable())
+            g_refreshThread.join();
     }
 
     void SpawnEnemy(int id, app::AgentMode__Enum agentMode)

--- a/GTFOHax/hacks/enemy.cpp
+++ b/GTFOHax/hacks/enemy.cpp
@@ -1,7 +1,10 @@
 #include "enemy.h"
 #include <cmath>
 #include <iostream>
-#include <set>
+#include <unordered_set>
+#include <unordered_map>
+#include <chrono>
+#include <format>
 #include <helpers.h>
 #include "aimbot.h"
 #include "esp.h"
@@ -9,34 +12,122 @@
 
 namespace Enemy
 {
-    std::vector<std::shared_ptr<EnemyInfo>> enemies;
-    std::vector<std::shared_ptr<EnemyInfo>> enemiesAimbot;
+    std::atomic<std::shared_ptr<EnemyVec>> enemies;
+    std::atomic<std::shared_ptr<EnemyVec>> enemiesAimbot;
     std::map<std::string, int> enemyIDs;
     std::vector<std::string> enemyNames;
-    
-    // Position tracking for movement direction calculation
+
     std::map<app::EnemyAgent*, EnemyPositionHistory> enemyPositionHistory;
     std::mutex enemyPositionHistoryMtx;
-    
+
+    struct BoneLineCastCache
+    {
+        app::Vector3 lastBonePos      = {0.0f, 0.0f, 0.0f};
+        app::Vector3 lastPlayerEyePos = {0.0f, 0.0f, 0.0f};
+        bool         lastVisible      = false;
+        bool         valid            = false;
+    };
+
+    struct EnemyCacheEntry
+    {
+        BoneLineCastCache boneCache[64];
+        app::Transform*   boneTransforms[64];
+        bool              boneTransformCached[64];
+        BoneLineCastCache fallbackCache;
+        std::string       enemyName;
+
+        EnemyCacheEntry()
+        {
+            memset(boneTransforms, 0, sizeof(boneTransforms));
+            memset(boneTransformCached, 0, sizeof(boneTransformCached));
+        }
+    };
+
+    static std::unordered_map<app::EnemyAgent*, EnemyCacheEntry> linecastCache;
+    static constexpr float BONE_MOVE_THRESHOLD_SQ = 0.01f * 0.01f; // 1cm
+    static constexpr float EYE_MOVE_THRESHOLD_SQ  = 0.01f * 0.01f; // 1cm
+
+    static constexpr int PERF_LOG_INTERVAL = 120;
+
+    struct PerfStats
+    {
+        int    frames      = 0;
+        double totalUs     = 0.0;
+        double minUs       = 1e9;
+        double maxUs       = 0.0;
+        int    raycasts    = 0;
+        int    cacheHits   = 0;
+        int    animCalls   = 0;
+
+        void record(double frameUs, int frameCasts, int frameHits, int frameAnimCalls)
+        {
+            ++frames;
+            totalUs    += frameUs;
+            if (frameUs < minUs) minUs = frameUs;
+            if (frameUs > maxUs) maxUs = frameUs;
+            raycasts   += frameCasts;
+            cacheHits  += frameHits;
+            animCalls  += frameAnimCalls;
+        }
+
+        void logAndReset()
+        {
+            if (frames == 0) return;
+            double avgUs    = totalUs / frames;
+            int    totalOps = raycasts + cacheHits;
+            float  hitRate  = totalOps > 0 ? 100.f * cacheHits / totalOps : 0.f;
+            il2cppi_log_write(std::format(
+                "[EnemyPerf] frames={} avg={:.1f}us min={:.1f}us max={:.1f}us | "
+                "animCalls={} raycasts={} cacheHits={} hitRate={:.1f}%",
+                frames, avgUs, minUs, maxUs,
+                animCalls, raycasts, cacheHits, hitRate));
+            *this = PerfStats{};
+        }
+    };
+    static PerfStats perf;
+
     app::Vector3 GetEnemyMovementDirection(app::EnemyAgent* enemy)
     {
         app::Vector3 zeroVec = {0.0f, 0.0f, 0.0f};
-        if (enemy == nullptr)
-            return zeroVec;
-            
+        if (enemy == nullptr) return zeroVec;
         std::lock_guard<std::mutex> lock(enemyPositionHistoryMtx);
         auto it = enemyPositionHistory.find(enemy);
         if (it != enemyPositionHistory.end() && it->second.hasValidDirection)
-        {
             return it->second.movementDirection;
-        }
         return zeroVec;
     }
-    
-    bool isBoneVisible(Enemy::Bone& bone)
+
+    static int s_frameCasts     = 0;
+    static int s_frameHits      = 0;
+    static int s_frameAnimCalls = 0;
+
+    static bool isBoneVisible_cached(BoneLineCastCache& cache, const app::Vector3& bonePos,
+                                     const app::Vector3& eyePos)
     {
-        bone.visible = !app::Physics_Linecast_1(G::localPlayer->fields.m_eyePosition, bone.position, (*app::LayerManager__TypeInfo)->static_fields->MASK_DEFAULT, NULL);
-        return bone.visible;
+        if (cache.valid)
+        {
+            float bdx = bonePos.x - cache.lastBonePos.x,
+                  bdy = bonePos.y - cache.lastBonePos.y,
+                  bdz = bonePos.z - cache.lastBonePos.z;
+            float edx = eyePos.x - cache.lastPlayerEyePos.x,
+                  edy = eyePos.y - cache.lastPlayerEyePos.y,
+                  edz = eyePos.z - cache.lastPlayerEyePos.z;
+            if (bdx*bdx + bdy*bdy + bdz*bdz < BONE_MOVE_THRESHOLD_SQ &&
+                edx*edx + edy*edy + edz*edz < EYE_MOVE_THRESHOLD_SQ)
+            {
+                ++s_frameHits;
+                return cache.lastVisible;
+            }
+        }
+        
+        ++s_frameCasts;
+        cache.lastVisible = !app::Physics_Linecast_1(
+            eyePos, bonePos,
+            (*app::LayerManager__TypeInfo)->static_fields->MASK_DEFAULT, NULL);
+        cache.lastBonePos      = bonePos;
+        cache.lastPlayerEyePos = eyePos;
+        cache.valid            = true;
+        return cache.lastVisible;
     }
 
     bool isValidDistance(bool visible, float distance)
@@ -47,15 +138,15 @@ namespace Enemy
                 return true;
             if (Aimbot::settings.toggleKey.isToggled() && distance < Aimbot::settings.maxDistance)
                 return true;
-            return false;
         }
-        else {
+        else
+        {
             if (ESP::enemyESP.nonVisibleSec.show && distance < ESP::enemyESP.nonVisibleSec.renderDistance)
                 return true;
             if (Aimbot::settings.toggleKey.isToggled() && !Aimbot::settings.visibleOnly && distance < Aimbot::settings.maxDistance)
                 return true;
-            return false;
         }
+        return false;
     }
 
     void _RefreshEnemyAgents()
@@ -65,192 +156,211 @@ namespace Enemy
         if (G::localPlayer == nullptr)
             return;
 
-        std::vector<std::shared_ptr<EnemyInfo>> enemiesTemp;
+        auto perfStart  = std::chrono::high_resolution_clock::now();
+        s_frameCasts    = 0;
+        s_frameHits      = 0;
+        s_frameAnimCalls = 0;
+
+        app::Vector3 eyePos = G::localPlayer->fields.m_eyePosition;
+        app::Vector3 localPos = G::localPlayer->fields.m_goodPosition;
+
+        const bool needVisibilityCheck =
+            ESP::enemyESP.visibleSec.show || ESP::enemyESP.nonVisibleSec.show ||
+            (Aimbot::settings.toggleKey.isToggled() && Aimbot::settings.visibleOnly);
+
+        static EnemyVec enemiesTemp;
+        enemiesTemp.clear();
+        if (enemiesTemp.capacity() < 64) enemiesTemp.reserve(128);
 
         auto courseNodesList = (*app::StaticUpdateManager__TypeInfo)->static_fields->courseNodes;
         for (int i = 0; i < courseNodesList->fields._size; i++)
         {
             auto courseNode = courseNodesList->fields._items->vector[i];
+            if (!courseNode) continue;
             auto enemiesList = courseNode->fields.m_enemiesInNode;
+            if (!enemiesList) continue;
+
             for (int j = 0; j < enemiesList->fields._size; j++)
             {
                 auto enemyAgent = enemiesList->fields._items->vector[j];
-                if (enemyAgent == NULL)
+                if (enemyAgent == NULL || !enemyAgent->fields.m_alive)
+                    continue;
+
+                app::Vector3 enemyPos = app::EnemyAgent_get_Position(enemyAgent, NULL);
+                float dx = enemyPos.x - localPos.x, dy = enemyPos.y - localPos.y, dz = enemyPos.z - localPos.z;
+                float distanceSq = dx*dx + dy*dy + dz*dz;
+                float distance = sqrtf(distanceSq);
+
+                float maxDist = (std::max<float>)((std::max<float>)((float)ESP::enemyESP.visibleSec.renderDistance, (float)ESP::enemyESP.nonVisibleSec.renderDistance), (float)Aimbot::settings.maxDistance);
+                if (distance > maxDist)
                 {
-                    //std::cout << "found null enemyAgent\n";
+                    if (distance > maxDist + 50.0f) linecastCache.erase(enemyAgent);
                     continue;
                 }
 
-                float distance = app::Vector3_Distance(app::EnemyAgent_get_Position(enemyAgent, NULL), G::localPlayer->fields.m_goodPosition, NULL);
-                if ((!Aimbot::settings.toggleKey.isToggled() || distance > Aimbot::settings.maxDistance)
-                    && (!ESP::enemyESP.visibleSec.show || distance > ESP::enemyESP.visibleSec.renderDistance)
-                    && (!ESP::enemyESP.nonVisibleSec.show || distance > ESP::enemyESP.nonVisibleSec.renderDistance))
-                {
-                    continue; // No point of keeping around info of enemies we don't use
-                }
+                auto& cacheEntry = linecastCache[enemyAgent];
+                if (cacheEntry.enemyName.empty())
+                    cacheEntry.enemyName = il2cppi_to_string(
+                        app::Object_1_GetName(reinterpret_cast<app::Object_1*>(enemyAgent), NULL));
 
-                app::Object_1* enemyObject = reinterpret_cast<app::Object_1*>(enemyAgent);
-                std::string enemyName = il2cppi_to_string(app::Object_1_GetName(enemyObject, NULL));
+                struct TempLimb { app::Vector3 pos; app::Dam_EnemyDamageLimb* ptr; };
+                TempLimb tempLimbs[32];
+                int tempLimbCount = 0;
 
-                using h = std::hash<float>;
-                static auto hash = [](const app::Vector3& v) { return h()(v.x) + h()(v.y) + h()(v.z); };
-                static auto equal = [](const app::Vector3& lhs, const app::Vector3& rhs) { return lhs.x == rhs.x && lhs.y == rhs.y && lhs.z == rhs.z; };
-                std::unordered_map<app::Vector3, app::Dam_EnemyDamageLimb*, decltype(hash), decltype(equal)> damageableBones(8, hash, equal);
-                std::vector<Bone> damageableBonesVec;
+                auto enemyInfo = std::make_shared<EnemyInfo>();
+                enemyInfo->visible = false;
+                enemyInfo->enemyAgent = enemyAgent;
+                enemyInfo->enemyObjectName = cacheEntry.enemyName;
+                enemyInfo->distance = distance;
 
                 auto damageLimbsList = enemyAgent->fields.Damage->fields.DamageLimbs;
-                auto damageLimbs = damageLimbsList->vector;
-
-                for (int i = 0; i < damageLimbsList->max_length; i++)
-                {
-                    auto limb = damageLimbs[i];
-                    auto limbPos = app::Dam_EnemyDamageLimb_get_DamageTargetPos(limb, NULL);
-                    damageableBones.insert(std::pair<app::Vector3, app::Dam_EnemyDamageLimb*>(limbPos, limb));
-
-                    Bone bone;
-                    bone.position = limbPos;
-                    isBoneVisible(bone);
-                    bone.damageable = true;
-                    bone.destroyed = limb->fields._IsDestroyed_k__BackingField;
-                    bone.limbType = limb->fields.m_type;
-                    bone.health = limb->fields.m_health;
-                    bone.limbPtr = limb;  // Store limb pointer for real-time position update
-                    damageableBonesVec.push_back(bone);
-                }
-
-                std::map<app::HumanBodyBones__Enum, Bone> bonesMap;
-                bool visible = false;
-                for (std::vector<app::HumanBodyBones__Enum>::const_iterator it = Enemy::WantedBones.begin(); it != Enemy::WantedBones.end(); ++it)
-                {
-                    auto boneTransform = app::Animator_GetBoneTransform(enemyAgent->fields.Anim, (*it), NULL);
-                    if (boneTransform == NULL)
-                        continue;
-                    Bone bone;
-                    bone.position = app::Transform_get_position(boneTransform, NULL);
-                    if (isBoneVisible(bone))
-                        visible = true;
-                    if (damageableBones.contains(bone.position))
+                if (damageLimbsList) {
+                    auto damageLimbs = damageLimbsList->vector;
+                    int limbCount = (std::min)((int)damageLimbsList->max_length, 32);
+                    for (int k = 0; k < limbCount; k++)
                     {
-                        auto damageableBone = damageableBones[bone.position];
+                        auto limb = damageLimbs[k];
+                        if (!limb) continue;
+                        auto limbPos = app::Dam_EnemyDamageLimb_get_DamageTargetPos(limb, NULL);
+                        tempLimbs[tempLimbCount++] = { limbPos, limb };
+                        Bone& bone = enemyInfo->damageableBones[enemyInfo->damageableBoneCount++];
+                        bone.position = limbPos;
                         bone.damageable = true;
-                        bone.destroyed = damageableBone->fields._IsDestroyed_k__BackingField;
-                        bone.limbType = damageableBone->fields.m_type;
-                        bone.health = damageableBone->fields.m_health;
+                        bone.destroyed = limb->fields._IsDestroyed_k__BackingField;
+                        bone.limbType = limb->fields.m_type;
+                        bone.health = limb->fields.m_health;
+                        bone.limbPtr = limb;
                     }
-                    bonesMap.insert(std::pair<app::HumanBodyBones__Enum, Bone>((*it), bone));
                 }
-                if (!bonesMap.contains(app::HumanBodyBones__Enum::Head) ||
-                    !bonesMap.contains(app::HumanBodyBones__Enum::LeftFoot) ||
-                    !bonesMap.contains(app::HumanBodyBones__Enum::RightFoot))
-                {
-                    Bone fallbackBone;
-                    fallbackBone.position = app::EnemyAgent_get_Position(enemyAgent, NULL);
-                    if (isBoneVisible(fallbackBone))
-                        visible = true;
 
-                    float distance = app::Vector3_Distance(fallbackBone.position, G::localPlayer->fields.m_goodPosition, NULL);
-                    if (!isValidDistance(visible, distance))
-                        continue;
-                    auto enInfo = std::shared_ptr<EnemyInfo>(new EnemyInfo(visible, bonesMap, damageableBonesVec, enemyAgent, enemyName, distance, fallbackBone));
-                    enemiesTemp.push_back(enInfo);
-                }
-                else
+                for (auto boneType : Enemy::WantedBones)
                 {
-                    float distance = app::Vector3_Distance(bonesMap[app::HumanBodyBones__Enum::Head].position, G::localPlayer->fields.m_goodPosition, NULL);
-                    if (!isValidDistance(visible, distance))
-                        continue;
-                    auto enInfo = std::shared_ptr<EnemyInfo>(new EnemyInfo(visible, bonesMap, damageableBonesVec, enemyAgent, enemyName, distance));
-                    enemiesTemp.push_back(enInfo);
+                    int idx = static_cast<int>(boneType);
+                    if (idx < 0 || idx >= 64) continue;
+
+                    app::Transform* boneTransform;
+                    if (cacheEntry.boneTransformCached[idx])
+                    {
+                        boneTransform = cacheEntry.boneTransforms[idx];
+                    }
+                    else
+                    {
+                        ++s_frameAnimCalls;
+                        boneTransform = app::Animator_GetBoneTransform(enemyAgent->fields.Anim, boneType, NULL);
+                        cacheEntry.boneTransforms[idx] = boneTransform;
+                        cacheEntry.boneTransformCached[idx] = true;
+                    }
+                    if (boneTransform == nullptr) continue;
+
+                    Bone bone;
+                    app::Transform_get_position_Injected(boneTransform, &bone.position, NULL);
+
+                    if (needVisibilityCheck)
+                    {
+                        auto& boneCache = cacheEntry.boneCache[idx];
+                        if (isBoneVisible_cached(boneCache, bone.position, eyePos))
+                            enemyInfo->visible = true;
+                        bone.visible = boneCache.lastVisible;
+                    }
+
+                    for (int k = 0; k < tempLimbCount; k++) {
+                        if (tempLimbs[k].pos.x == bone.position.x &&
+                            tempLimbs[k].pos.y == bone.position.y &&
+                            tempLimbs[k].pos.z == bone.position.z) {
+                            auto db = tempLimbs[k].ptr;
+                            bone.damageable = true;
+                            bone.destroyed = db->fields._IsDestroyed_k__BackingField;
+                            bone.limbType = db->fields.m_type;
+                            bone.health = db->fields.m_health;
+                            bone.limbPtr = db;
+                            break;
+                        }
+                    }
+
+                    enemyInfo->bones[idx] = std::move(bone);
+                    enemyInfo->hasBone[idx] = true;
                 }
+
+                bool hasEssentialBones = enemyInfo->hasBone[static_cast<int>(app::HumanBodyBones__Enum::Head)] &&
+                                         enemyInfo->hasBone[static_cast<int>(app::HumanBodyBones__Enum::LeftFoot)] &&
+                                         enemyInfo->hasBone[static_cast<int>(app::HumanBodyBones__Enum::RightFoot)];
+
+                if (!hasEssentialBones)
+                {
+                    enemyInfo->fallbackBone.position = enemyPos;
+                    if (needVisibilityCheck)
+                    {
+                        isBoneVisible_cached(cacheEntry.fallbackCache, enemyInfo->fallbackBone.position, eyePos);
+                        enemyInfo->fallbackBone.visible = cacheEntry.fallbackCache.lastVisible;
+                        enemyInfo->visible = enemyInfo->fallbackBone.visible;
+                    }
+                    enemyInfo->useFallback = true;
+                }
+
+                if (isValidDistance(enemyInfo->visible, distance))
+                    enemiesTemp.push_back(std::move(enemyInfo));
             }
         }
 
-        G::enemyVecMtx.lock();
-        enemies.clear();
-        enemies = enemiesTemp;
-        G::enemyVecMtx.unlock();
-
-        G::enemyAimMtx.lock();
-        enemiesAimbot.clear();
-        enemiesAimbot = enemiesTemp;
-        G::enemyAimMtx.unlock();
-        
-        // Update position history for movement direction tracking
+        std::unordered_set<app::EnemyAgent*> validEnemies;
         {
             std::lock_guard<std::mutex> lock(enemyPositionHistoryMtx);
-            
-            // Track which enemies are still valid
-            std::set<app::EnemyAgent*> validEnemies;
-            
             for (const auto& enemyInfo : enemiesTemp)
             {
                 app::EnemyAgent* agent = enemyInfo->enemyAgent;
                 validEnemies.insert(agent);
-                
                 app::Vector3 currentPos = app::EnemyAgent_get_Position(agent, NULL);
-                
                 auto it = enemyPositionHistory.find(agent);
                 if (it != enemyPositionHistory.end())
                 {
-                    // Update existing entry
                     it->second.previousPosition = it->second.currentPosition;
-                    it->second.currentPosition = currentPos;
-                    
-                    // Calculate movement direction
-                    app::Vector3 delta;
-                    delta.x = currentPos.x - it->second.previousPosition.x;
-                    delta.y = 0.0f;  // Ignore vertical movement for horizontal direction
-                    delta.z = currentPos.z - it->second.previousPosition.z;
-                    
-                    float len = sqrtf(delta.x * delta.x + delta.z * delta.z);
-                    if (len > 0.01f)  // Moving threshold
+                    it->second.currentPosition  = currentPos;
+                    float dx = currentPos.x - it->second.previousPosition.x;
+                    float dz = currentPos.z - it->second.previousPosition.z;
+                    float lenSq = dx*dx + dz*dz;
+                    if (lenSq > 0.0001f)
                     {
-                        it->second.movementDirection.x = delta.x / len;
-                        it->second.movementDirection.y = 0.0f;
-                        it->second.movementDirection.z = delta.z / len;
+                        float len = sqrtf(lenSq);
+                        it->second.movementDirection = { dx / len, 0.0f, dz / len };
                         it->second.hasValidDirection = true;
                     }
-                    // Keep previous direction if not moving significantly
                 }
                 else
-                {
-                    // New enemy, initialize
-                    EnemyPositionHistory history;
-                    history.previousPosition = currentPos;
-                    history.currentPosition = currentPos;
-                    history.movementDirection = {0.0f, 0.0f, 0.0f};
-                    history.hasValidDirection = false;
-                    enemyPositionHistory[agent] = history;
-                }
+                    enemyPositionHistory[agent] = { currentPos, currentPos, {0,0,0}, false };
             }
-            
-            // Clean up entries for enemies that no longer exist
             for (auto it = enemyPositionHistory.begin(); it != enemyPositionHistory.end(); )
             {
                 if (validEnemies.find(it->first) == validEnemies.end())
-                {
                     it = enemyPositionHistory.erase(it);
-                }
                 else
-                {
                     ++it;
-                }
             }
         }
+
+        for (auto it = linecastCache.begin(); it != linecastCache.end(); )
+            it = validEnemies.count(it->first) ? std::next(it) : linecastCache.erase(it);
+
+        auto sharedVec = std::make_shared<EnemyVec>(std::move(enemiesTemp));
+        enemies.store(sharedVec);
+        enemiesAimbot.store(std::move(sharedVec));
+
+        auto perfEnd = std::chrono::high_resolution_clock::now();
+        double frameUs = std::chrono::duration<double, std::micro>(perfEnd - perfStart).count();
+        perf.record(frameUs, s_frameCasts, s_frameHits, s_frameAnimCalls);
+        if (perf.frames >= PERF_LOG_INTERVAL)
+            perf.logAndReset();
     }
 
     void _SpawnEnemy(int id, app::AgentMode__Enum agentMode)
     {
         app::EnemyAllocator* enemyAllocator = (*app::EnemyAllocator__TypeInfo)->static_fields->Current;
         app::PlayerAgent* localPlayer = app::PlayerManager_2_GetLocalPlayerAgent(nullptr);
+        if (!localPlayer) return;
         app::Agent* localPlayerAgent = reinterpret_cast<app::Agent*>(localPlayer);
         app::Quaternion playerRotation = app::Agent_get_Rotation(localPlayerAgent, NULL);
         app::AIG_CourseNode* courseNode = localPlayer->fields.m_courseNode;
 
-        app::Vector3 screenCenter;
-        screenCenter.x = G::screenWidth / 2.0f;
-        screenCenter.y = G::screenHeight / 2.0f;
-        screenCenter.z = 0;
+        app::Vector3 screenCenter = { G::screenWidth / 2.0f, G::screenHeight / 2.0f, 0 };
         app::Ray screenCenterRay = app::Camera_ScreenPointToRay_2(G::mainCamera, screenCenter, NULL);
         app::RaycastHit raycastHit;
         if (app::Physics_Raycast_14(screenCenterRay, &raycastHit, 200, NULL))
@@ -265,9 +375,8 @@ namespace Enemy
         G::callbacks.push([] { _RefreshEnemyAgents(); });
     }
 
-    void SpawnEnemy(int id, app::AgentMode__Enum agentMode = app::AgentMode__Enum::Off)
+    void SpawnEnemy(int id, app::AgentMode__Enum agentMode)
     {
         G::callbacks.push([id, agentMode] { _SpawnEnemy(id, agentMode); });
     }
 }
-

--- a/GTFOHax/hacks/enemy.cpp
+++ b/GTFOHax/hacks/enemy.cpp
@@ -66,9 +66,6 @@ namespace Enemy
         BoneLineCastCache fallback;
     };
     static std::unordered_map<app::EnemyAgent*, GameVisCache> g_gameVisCache;
-    static constexpr float BONE_MOVE_THRESHOLD_SQ = 0.01f * 0.01f; // 1cm
-    static constexpr float EYE_MOVE_THRESHOLD_SQ  = 0.01f * 0.01f; // 1cm
-
     struct EnemyInfoPool
     {
         std::vector<std::unique_ptr<EnemyInfo>> slots;
@@ -128,19 +125,11 @@ namespace Enemy
     static bool isBoneVisible_cached(BoneLineCastCache& cache, const app::Vector3& bonePos,
                                      const app::Vector3& eyePos)
     {
-        if (cache.valid)
+        if (cache.valid &&
+            bonePos.x == cache.lastBonePos.x && bonePos.y == cache.lastBonePos.y && bonePos.z == cache.lastBonePos.z &&
+            eyePos.x  == cache.lastPlayerEyePos.x && eyePos.y == cache.lastPlayerEyePos.y && eyePos.z == cache.lastPlayerEyePos.z)
         {
-            float bdx = bonePos.x - cache.lastBonePos.x,
-                  bdy = bonePos.y - cache.lastBonePos.y,
-                  bdz = bonePos.z - cache.lastBonePos.z;
-            float edx = eyePos.x - cache.lastPlayerEyePos.x,
-                  edy = eyePos.y - cache.lastPlayerEyePos.y,
-                  edz = eyePos.z - cache.lastPlayerEyePos.z;
-            if (bdx*bdx + bdy*bdy + bdz*bdz < BONE_MOVE_THRESHOLD_SQ &&
-                edx*edx + edy*edy + edz*edz < EYE_MOVE_THRESHOLD_SQ)
-            {
-                return cache.lastVisible;
-            }
+            return cache.lastVisible;
         }
 
         if (!g_maskResolved)

--- a/GTFOHax/hacks/enemy.cpp
+++ b/GTFOHax/hacks/enemy.cpp
@@ -113,78 +113,6 @@ namespace Enemy
     static constexpr uint32_t CACHE_STALE_FRAMES   = 600;
     static constexpr uint32_t CACHE_SWEEP_INTERVAL = 120;
 
-    static constexpr int PERF_LOG_INTERVAL = 120;
-
-    struct PerfStats
-    {
-        int    frames      = 0;
-        double totalUs     = 0.0;
-        double loopUs      = 0.0;
-        double sweepUs     = 0.0;
-        double publishUs   = 0.0;
-        double bonePosUs   = 0.0;   // Transform_get_position_Injected
-        double limbPosUs   = 0.0;   // Dam_EnemyDamageLimb_get_DamageTargetPos
-        double animUs      = 0.0;   // Animator_GetBoneTransform
-        double visUs       = 0.0;   // isBoneVisible_cached (incl. raycasts)
-        double minUs       = 1e9;
-        double maxUs       = 0.0;
-        int    raycasts    = 0;
-        int    cacheHits   = 0;
-        int    animCalls   = 0;
-        int    enemyCount  = 0;
-        int    staleCount  = 0;
-
-        void record(double frameUs, double frameLoopUs, double frameSweepUs, double framePublishUs,
-                    double frameBonePosUs, double frameLimbPosUs, double frameAnimUs, double frameVisUs,
-                    int frameCasts, int frameHits, int frameAnimCalls, int frameEnemies, int frameStale)
-        {
-            ++frames;
-            totalUs    += frameUs;
-            loopUs     += frameLoopUs;
-            sweepUs    += frameSweepUs;
-            publishUs  += framePublishUs;
-            bonePosUs  += frameBonePosUs;
-            limbPosUs  += frameLimbPosUs;
-            animUs     += frameAnimUs;
-            visUs      += frameVisUs;
-            if (frameUs < minUs) minUs = frameUs;
-            if (frameUs > maxUs) maxUs = frameUs;
-            raycasts   += frameCasts;
-            cacheHits  += frameHits;
-            animCalls  += frameAnimCalls;
-            enemyCount += frameEnemies;
-            staleCount += frameStale;
-        }
-
-        void logAndReset()
-        {
-            if (frames == 0) return;
-            double avgUs        = totalUs   / frames;
-            double avgLoopUs    = loopUs    / frames;
-            double avgSweepUs   = sweepUs   / frames;
-            double avgPublishUs = publishUs / frames;
-            double avgBonePosUs = bonePosUs / frames;
-            double avgLimbPosUs = limbPosUs / frames;
-            double avgAnimUs    = animUs    / frames;
-            double avgVisUs     = visUs     / frames;
-            int    totalOps     = raycasts + cacheHits;
-            float  hitRate      = totalOps > 0 ? 100.f * cacheHits / totalOps : 0.f;
-            int   totalProcessed = enemyCount + staleCount;
-            float stalePct       = totalProcessed > 0 ? 100.f * staleCount / totalProcessed : 0.f;
-            il2cppi_log_write(std::format(
-                "[EnemyPerf] frames={} avg={:.1f}us min={:.1f}us max={:.1f}us | "
-                "loop={:.1f}us sweep={:.1f}us publish={:.1f}us | "
-                "bones+vis={:.1f}us limbs={:.1f}us anim={:.1f}us | "
-                "enemyCount={} stale={:.0f} stalePct={:.1f}% animCalls={} raycasts={} cacheHits={} hitRate={:.1f}%",
-                frames, avgUs, minUs, maxUs,
-                avgLoopUs, avgSweepUs, avgPublishUs,
-                avgBonePosUs, avgLimbPosUs, avgAnimUs,
-                enemyCount / frames, (double)staleCount / frames, stalePct,
-                animCalls, raycasts, cacheHits, hitRate));
-            *this = PerfStats{};
-        }
-    };
-    static PerfStats perf;
 
     app::Vector3 GetEnemyMovementDirection(app::EnemyAgent* enemy)
     {
@@ -196,10 +124,6 @@ namespace Enemy
             return it->second.movementDirection;
         return zeroVec;
     }
-
-    static int s_frameCasts     = 0;
-    static int s_frameHits      = 0;
-    static int s_frameAnimCalls = 0;
 
     static bool isBoneVisible_cached(BoneLineCastCache& cache, const app::Vector3& bonePos,
                                      const app::Vector3& eyePos)
@@ -215,12 +139,10 @@ namespace Enemy
             if (bdx*bdx + bdy*bdy + bdz*bdz < BONE_MOVE_THRESHOLD_SQ &&
                 edx*edx + edy*edy + edz*edz < EYE_MOVE_THRESHOLD_SQ)
             {
-                ++s_frameHits;
                 return cache.lastVisible;
             }
         }
-        
-        ++s_frameCasts;
+
         if (!g_maskResolved)
         {
             g_maskDefault  = (*app::LayerManager__TypeInfo)->static_fields->MASK_DEFAULT;
@@ -270,23 +192,11 @@ namespace Enemy
 
         ++g_refreshFrame;
 
-        auto perfStart  = std::chrono::high_resolution_clock::now();
-        s_frameCasts    = 0;
-        s_frameHits      = 0;
-        s_frameAnimCalls = 0;
-
-        double frameBonePosUs = 0.0;
-        double frameLimbPosUs = 0.0;
-        double frameAnimUs    = 0.0;
-        double frameVisUs     = 0.0;
-        int    frameEnemyCount = 0;
-
         app::Vector3 localPos = G::localPlayer->fields.m_goodPosition;
         static EnemyVec enemiesTemp;
         enemiesTemp.clear();
         if (enemiesTemp.capacity() < 64) enemiesTemp.reserve(128);
 
-        auto loopStart = std::chrono::high_resolution_clock::now();
         auto courseNodesList = (*app::StaticUpdateManager__TypeInfo)->static_fields->courseNodes;
         for (int i = 0; i < courseNodesList->fields._size; i++)
         {
@@ -352,8 +262,6 @@ namespace Enemy
                 enemyInfo->enemyObjectName = cacheEntry.enemyName;
                 enemyInfo->distance = distance;
 
-                ++frameEnemyCount;
-                auto t0enemy = std::chrono::high_resolution_clock::now();
                 auto damageLimbsList = enemyAgent->fields.Damage->fields.DamageLimbs;
                 if (damageLimbsList) {
                     if (!cacheEntry.cachedLimbsReady) {
@@ -385,9 +293,6 @@ namespace Enemy
                         bone.limbPtr   = cl.ptr;
                     }
                 }
-                frameLimbPosUs += std::chrono::duration<double, std::micro>(std::chrono::high_resolution_clock::now() - t0enemy).count();
-
-                auto t0bones = std::chrono::high_resolution_clock::now();
                 for (auto boneType : Enemy::WantedBones)
                 {
                     int idx = static_cast<int>(boneType);
@@ -400,10 +305,7 @@ namespace Enemy
                     }
                     else
                     {
-                        ++s_frameAnimCalls;
                         boneTransform = app::Animator_GetBoneTransform(enemyAgent->fields.Anim, boneType, NULL);
-                        frameAnimUs += std::chrono::duration<double, std::micro>(std::chrono::high_resolution_clock::now() - t0bones).count();
-                        t0bones = std::chrono::high_resolution_clock::now();
                         cacheEntry.boneTransforms[idx] = boneTransform;
                         cacheEntry.boneTransformCached[idx] = true;
                     }
@@ -438,7 +340,6 @@ namespace Enemy
                     enemyInfo->bones[idx] = std::move(bone);
                     enemyInfo->hasBone[idx] = true;
                 }
-                frameBonePosUs += std::chrono::duration<double, std::micro>(std::chrono::high_resolution_clock::now() - t0bones).count();
 
                 bool hasEssentialBones = enemyInfo->hasBone[static_cast<int>(app::HumanBodyBones__Enum::Head)] &&
                                          enemyInfo->hasBone[static_cast<int>(app::HumanBodyBones__Enum::LeftFoot)] &&
@@ -456,12 +357,7 @@ namespace Enemy
                     enemiesTemp.push_back(std::move(enemyInfo));
             }
         }
-        auto loopEnd = std::chrono::high_resolution_clock::now();
 
-        // Periodic lazy sweep: entries that weren't touched within CACHE_STALE_FRAMES
-        // are evicted. Runs every CACHE_SWEEP_INTERVAL frames,
-        // so the steady-state per-frame cost of cleanup is zero.
-        auto sweepStart = std::chrono::high_resolution_clock::now();
         if ((g_refreshFrame % CACHE_SWEEP_INTERVAL) == 0)
         {
             for (auto it = linecastCache.begin(); it != linecastCache.end(); )
@@ -482,22 +378,8 @@ namespace Enemy
                 }
             }
         }
-        auto sweepEnd = std::chrono::high_resolution_clock::now();
 
-        auto publishStart = std::chrono::high_resolution_clock::now();
         enemies.store(std::make_shared<EnemyVec>(std::move(enemiesTemp)));
-        auto publishEnd = std::chrono::high_resolution_clock::now();
-
-        auto perfEnd = std::chrono::high_resolution_clock::now();
-        double frameUs   = std::chrono::duration<double, std::micro>(perfEnd      - perfStart    ).count();
-        double loopMs    = std::chrono::duration<double, std::micro>(loopEnd      - loopStart   ).count();
-        double sweepMs   = std::chrono::duration<double, std::micro>(sweepEnd     - sweepStart  ).count();
-        double publishMs = std::chrono::duration<double, std::micro>(publishEnd   - publishStart).count();
-        perf.record(frameUs, loopMs, sweepMs, publishMs,
-                    frameBonePosUs, frameLimbPosUs, frameAnimUs, 0.0,
-                    s_frameCasts, s_frameHits, s_frameAnimCalls, frameEnemyCount, 0);
-        if (perf.frames >= PERF_LOG_INTERVAL)
-            perf.logAndReset();
     }
 
     void _SpawnEnemy(int id, app::AgentMode__Enum agentMode)

--- a/GTFOHax/hacks/enemy.h
+++ b/GTFOHax/hacks/enemy.h
@@ -2,6 +2,7 @@
 #include "globals.h"
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <atomic>
 
 namespace Enemy
@@ -110,6 +111,20 @@ namespace Enemy
             memset(screenPositionsValid, 0, sizeof(screenPositionsValid));
         }
 
+        void reset()
+        {
+            visible = false;
+            enemyAgent = nullptr;
+            distance = 0;
+            useFallback = false;
+            damageableBoneCount = 0;
+            enemyObjectName.clear();
+            memset(hasBone, 0, sizeof(hasBone));
+            memset(screenPositionsValid, 0, sizeof(screenPositionsValid));
+            // bones[] / damageableBones[] / fallbackBone / screenPositions[]
+            // are written before being read again, so no reset needed here.
+        }
+
         inline const Bone* getBone(app::HumanBodyBones__Enum boneType) const
         {
             int idx = static_cast<int>(boneType);
@@ -120,8 +135,8 @@ namespace Enemy
     };
 
     using EnemyVec = std::vector<std::shared_ptr<EnemyInfo>>;
-    extern std::atomic<std::shared_ptr<EnemyVec>> enemies;
-    extern std::atomic<std::shared_ptr<EnemyVec>> enemiesAimbot;
+    extern std::atomic<std::shared_ptr<EnemyVec>> enemies;      // pending: background thread (positions only)
+    extern std::atomic<std::shared_ptr<EnemyVec>> enemiesReady; // ready: game thread visibility-annotated
     extern std::map<std::string, int> enemyIDs;
     extern std::vector<std::string> enemyNames;
     
@@ -132,14 +147,17 @@ namespace Enemy
         app::Vector3 currentPosition;
         app::Vector3 movementDirection;  // Normalized direction
         bool hasValidDirection;
+        uint32_t lastTouchFrame;
     };
-    extern std::map<app::EnemyAgent*, EnemyPositionHistory> enemyPositionHistory;
-    extern std::mutex enemyPositionHistoryMtx;
-    
-    // Get the movement direction of an enemy (returns normalized vector, or zero vector if not moving)
+    extern std::unordered_map<app::EnemyAgent*, EnemyPositionHistory> enemyPositionHistory;
+
+    // Get the movement direction of an enemy (returns normalized vector, or zero vector if not moving).
+    // Must be called from the same (main/game) thread that drives _RefreshEnemyAgents.
     app::Vector3 GetEnemyMovementDirection(app::EnemyAgent* enemy);
 
     void _RefreshEnemyAgents();
     void RefreshEnemyAgents();
+    void UpdateEnemyVisibility();
+    void StopRefreshThread();
     void SpawnEnemy(int id, app::AgentMode__Enum agentMode);
 }

--- a/GTFOHax/hacks/enemy.h
+++ b/GTFOHax/hacks/enemy.h
@@ -2,6 +2,7 @@
 #include "globals.h"
 #include <vector>
 #include <map>
+#include <atomic>
 
 namespace Enemy
 {
@@ -88,39 +89,39 @@ namespace Enemy
     {
         bool visible;
         app::EnemyAgent* enemyAgent;
-        std::map<app::HumanBodyBones__Enum, Bone> skeletonBones;
-        std::vector<Bone> damageableBones;
+        
+        Bone bones[64];
+        bool hasBone[64];
+        
+        ImVec2 screenPositions[64];
+        bool screenPositionsValid[64];
+
+        Bone damageableBones[32];
+        int  damageableBoneCount;
         Bone fallbackBone;
         std::string enemyObjectName;
         float distance;
         bool useFallback;
 
-        EnemyInfo(bool visible, std::map<app::HumanBodyBones__Enum, Bone> skeletonBones, std::vector<Bone> damageableBones, app::EnemyAgent* enemyAgent, std::string enemyObjectName, float distance)
+        // Efficient constructor
+        EnemyInfo() : visible(false), enemyAgent(nullptr), distance(0), useFallback(false), damageableBoneCount(0)
         {
-            this->visible = visible;
-            this->skeletonBones = skeletonBones;
-            this->damageableBones = damageableBones;
-            this->enemyAgent = enemyAgent;
-            this->enemyObjectName = enemyObjectName;
-            this->distance = distance;
-            this->useFallback = false;
+            memset(hasBone, 0, sizeof(hasBone));
+            memset(screenPositionsValid, 0, sizeof(screenPositionsValid));
         }
-        
-        EnemyInfo(bool visible, std::map<app::HumanBodyBones__Enum, Bone> skeletonBones, std::vector<Bone> damageableBones, app::EnemyAgent* enemyAgent, std::string enemyObjectName, float distance, Bone fallbackBone)
+
+        inline const Bone* getBone(app::HumanBodyBones__Enum boneType) const
         {
-            this->visible = visible;
-            this->skeletonBones = skeletonBones;
-            this->damageableBones = damageableBones;
-            this->enemyAgent = enemyAgent;
-            this->enemyObjectName = enemyObjectName;
-            this->distance = distance;
-            this->fallbackBone = fallbackBone;
-            this->useFallback = true;
+            int idx = static_cast<int>(boneType);
+            if (idx >= 0 && idx < 64 && hasBone[idx])
+                return &bones[idx];
+            return nullptr;
         }
     };
 
-    extern std::vector<std::shared_ptr<EnemyInfo>> enemies;
-    extern std::vector<std::shared_ptr<EnemyInfo>> enemiesAimbot;
+    using EnemyVec = std::vector<std::shared_ptr<EnemyInfo>>;
+    extern std::atomic<std::shared_ptr<EnemyVec>> enemies;
+    extern std::atomic<std::shared_ptr<EnemyVec>> enemiesAimbot;
     extern std::map<std::string, int> enemyIDs;
     extern std::vector<std::string> enemyNames;
     

--- a/GTFOHax/hooks.cpp
+++ b/GTFOHax/hooks.cpp
@@ -167,6 +167,7 @@ void Hooks::InitHooks()
     HOOKATTACH(Cursor_set_visible);
 
     HOOKATTACH(LocalPlayerAgent_Update);
+    HOOKATTACH(LocalPlayerAgent_LateUpdate);
 
     HOOKATTACH(Dam_EnemyDamageBase_ProcessReceivedDamage);
     HOOKATTACH(ArchetypeDataBlock_GetSentryDamage);
@@ -424,14 +425,10 @@ bool Hooks::hkWeapon_CastWeaponRay_1(app::Transform* alignTransform, app::Weapon
                         bool isValid = false;
                         if (localTargetEnemy != nullptr)
                         {
-                            for (const auto& enemyInfo : Enemy::enemiesAimbot)
-                            {
-                                if (enemyInfo->enemyAgent == localTargetEnemy)
-                                {
-                                    isValid = true;
-                                    break;
-                                }
-                            }
+                            auto aimSnap = Enemy::enemiesAimbot.load();
+                            if (aimSnap)
+                                for (const auto& enemyInfo : *aimSnap)
+                                    if (enemyInfo->enemyAgent == localTargetEnemy) { isValid = true; break; }
                         }
                         
                         if (isValid)
@@ -496,14 +493,10 @@ bool Hooks::hkWeapon_CastWeaponRay_1(app::Transform* alignTransform, app::Weapon
                         bool isValid = false;
                         if (localTargetEnemy != nullptr)
                         {
-                            for (const auto& enemyInfo : Enemy::enemiesAimbot)
-                            {
-                                if (enemyInfo->enemyAgent == localTargetEnemy)
-                                {
-                                    isValid = true;
-                                    break;
-                                }
-                            }
+                            auto aimSnap = Enemy::enemiesAimbot.load();
+                            if (aimSnap)
+                                for (const auto& enemyInfo : *aimSnap)
+                                    if (enemyInfo->enemyAgent == localTargetEnemy) { isValid = true; break; }
                         }
                         
                         if (isValid)
@@ -610,21 +603,26 @@ bool Hooks::hkWeapon_CastWeaponRay_1(app::Transform* alignTransform, app::Weapon
                 
                 if (localTargetEnemy != nullptr)
                 {
-                    for (const auto& enemyInfo : Enemy::enemiesAimbot)
+                    auto aimSnap = Enemy::enemiesAimbot.load();
+                    for (const auto& enemyInfo : (aimSnap ? *aimSnap : Enemy::EnemyVec{}))
                     {
-                        if (enemyInfo->enemyAgent == localTargetEnemy && !enemyInfo->skeletonBones.empty())
+                        if (enemyInfo->enemyAgent == localTargetEnemy)
                         {
                             // Get real-time skeleton positions
                             std::map<app::HumanBodyBones__Enum, Enemy::Bone> currentBones;
                             for (const auto& boneType : Enemy::WantedBones)
                             {
-                                auto boneTransform = app::Animator_GetBoneTransform(
-                                    localTargetEnemy->fields.Anim, boneType, NULL);
-                                if (boneTransform != nullptr)
+                                const Enemy::Bone* b = enemyInfo->getBone(boneType);
+                                if (b)
                                 {
-                                    Enemy::Bone bone;
-                                    bone.position = app::Transform_get_position(boneTransform, NULL);
-                                    currentBones[boneType] = bone;
+                                    app::Transform* boneTransform = app::Animator_GetBoneTransform(
+                                        localTargetEnemy->fields.Anim, boneType, NULL);
+                                    if (boneTransform != nullptr)
+                                    {
+                                        Enemy::Bone bone = *b;
+                                        app::Transform_get_position_Injected(boneTransform, &bone.position, NULL);
+                                        currentBones[boneType] = bone;
+                                    }
                                 }
                             }
                             if (!currentBones.empty())
@@ -935,16 +933,21 @@ void Hooks::hkLocalPlayerAgent_Update(app::LocalPlayerAgent* __this, MethodInfo*
     static auto fpOFunc = reinterpret_cast<void (*)(app::LocalPlayerAgent*, MethodInfo*)>(hooks["LocalPlayerAgent_Update"]);
     fpOFunc(__this, method);
 
-    Enemy::_RefreshEnemyAgents();
+    G::localPlayer = reinterpret_cast<app::PlayerAgent*>(__this);
+
     while (!G::callbacks.empty())
     {
         G::callbacks.front()();
         G::callbacks.pop();
     }
 
-    G::w2CamMatrix = app::Camera_get_worldToCameraMatrix(G::mainCamera, NULL);
-    G::projMatrix = app::Camera_get_projectionMatrix(G::mainCamera, NULL);
-    G::viewMatrix = Math::MatrixMult(G::projMatrix, G::w2CamMatrix);
+    if (G::mainCamera != NULL)
+    {
+        std::lock_guard<std::mutex> lock(G::matrixMtx);
+        G::w2CamMatrix = app::Camera_get_worldToCameraMatrix(G::mainCamera, NULL);
+        G::projMatrix = app::Camera_get_projectionMatrix(G::mainCamera, NULL);
+        G::viewMatrix = Math::MatrixMult(G::projMatrix, G::w2CamMatrix);
+    }
 
     // Handle custom fullbright light
     static app::Light* fullBrightLight = nullptr;
@@ -1241,6 +1244,14 @@ LRESULT __stdcall WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         return TRUE;
     
     return CallWindowProc(G::oWndProc, hWnd, uMsg, wParam, lParam);
+}
+
+void Hooks::hkLocalPlayerAgent_LateUpdate(app::LocalPlayerAgent* __this, MethodInfo* method)
+{
+    static auto fpOFunc = reinterpret_cast<void (*)(app::LocalPlayerAgent*, MethodInfo*)>(hooks["LocalPlayerAgent_LateUpdate"]);
+    fpOFunc(__this, method);
+
+    Enemy::_RefreshEnemyAgents();
 }
 
 HRESULT __stdcall Hooks::hkPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags)

--- a/GTFOHax/hooks.cpp
+++ b/GTFOHax/hooks.cpp
@@ -425,7 +425,7 @@ bool Hooks::hkWeapon_CastWeaponRay_1(app::Transform* alignTransform, app::Weapon
                         bool isValid = false;
                         if (localTargetEnemy != nullptr)
                         {
-                            auto aimSnap = Enemy::enemiesAimbot.load();
+                            auto aimSnap = Enemy::enemiesReady.load();
                             if (aimSnap)
                                 for (const auto& enemyInfo : *aimSnap)
                                     if (enemyInfo->enemyAgent == localTargetEnemy) { isValid = true; break; }
@@ -493,7 +493,7 @@ bool Hooks::hkWeapon_CastWeaponRay_1(app::Transform* alignTransform, app::Weapon
                         bool isValid = false;
                         if (localTargetEnemy != nullptr)
                         {
-                            auto aimSnap = Enemy::enemiesAimbot.load();
+                            auto aimSnap = Enemy::enemiesReady.load();
                             if (aimSnap)
                                 for (const auto& enemyInfo : *aimSnap)
                                     if (enemyInfo->enemyAgent == localTargetEnemy) { isValid = true; break; }
@@ -603,7 +603,7 @@ bool Hooks::hkWeapon_CastWeaponRay_1(app::Transform* alignTransform, app::Weapon
                 
                 if (localTargetEnemy != nullptr)
                 {
-                    auto aimSnap = Enemy::enemiesAimbot.load();
+                    auto aimSnap = Enemy::enemiesReady.load();
                     for (const auto& enemyInfo : (aimSnap ? *aimSnap : Enemy::EnemyVec{}))
                     {
                         if (enemyInfo->enemyAgent == localTargetEnemy)
@@ -885,6 +885,7 @@ void Hooks::hkApplication_Quit(int32_t exitCode, MethodInfo* method)
     il2cppi_log_write("Application::Quit called. Shutting down...");
     G::gameQuit = true;
     G::running = false;
+    Enemy::StopRefreshThread();
     Hooks::RemoveHooks(false);
 
     // Trampoline is invalid after RemoveHooks, call original directly
@@ -896,6 +897,7 @@ void Hooks::hkApplication_Quit_1(MethodInfo* method)
     il2cppi_log_write("Application::Quit_1 called. Shutting down...");
     G::gameQuit = true;
     G::running = false;
+    Enemy::StopRefreshThread();
     Hooks::RemoveHooks(false);
 
     app::Application_Quit_1(method);
@@ -1251,7 +1253,8 @@ void Hooks::hkLocalPlayerAgent_LateUpdate(app::LocalPlayerAgent* __this, MethodI
     static auto fpOFunc = reinterpret_cast<void (*)(app::LocalPlayerAgent*, MethodInfo*)>(hooks["LocalPlayerAgent_LateUpdate"]);
     fpOFunc(__this, method);
 
-    Enemy::_RefreshEnemyAgents();
+    Enemy::RefreshEnemyAgents();
+    Enemy::UpdateEnemyVisibility();
 }
 
 HRESULT __stdcall Hooks::hkPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags)

--- a/GTFOHax/hooks.h
+++ b/GTFOHax/hooks.h
@@ -42,6 +42,7 @@ namespace Hooks
     void hkCursor_set_visible(bool value, MethodInfo* method);
 
     void hkLocalPlayerAgent_Update(app::LocalPlayerAgent* __this, MethodInfo* method);
+    void hkLocalPlayerAgent_LateUpdate(app::LocalPlayerAgent* __this, MethodInfo* method);
     bool hkDam_EnemyDamageBase_ProcessReceivedDamage(app::Dam_EnemyDamageBase* __this, float damage, app::Agent* damageSource,
         app::Vector3 position, app::Vector3 direction, app::ES_HitreactType__Enum hitreact, bool tryForceHitreact, int32_t limbID,
         float staggerDamageMulti, app::DamageNoiseLevel__Enum damageNoiseLevel,

--- a/GTFOHax/menu.cpp
+++ b/GTFOHax/menu.cpp
@@ -1042,7 +1042,7 @@ void RenderEnemyAgent(Enemy::EnemyInfo* enemyInfo, ESP::AgentESPSection* espSett
         std::string enemyName = "";
         if (espSettings->showName)
         {
-            enemyName = enemyInfo->enemyObjectName;
+            enemyName = std::string(enemyInfo->enemyObjectName);
             auto gPrefabIndex = enemyName.find("GeneratedPrefab");
             if (gPrefabIndex != std::string::npos)
             {
@@ -1119,7 +1119,7 @@ void RenderEnemyAgent(Enemy::EnemyInfo* enemyInfo, ESP::AgentESPSection* espSett
 
 void RenderEnemyESP()
 {
-    auto enemiesSnap = Enemy::enemies.load();
+    auto enemiesSnap = Enemy::enemiesReady.load();
     if (!enemiesSnap || enemiesSnap->empty()) return;
 
     // Use a temporary vector of pointers for sorting to avoid copying shared_ptrs

--- a/GTFOHax/menu.cpp
+++ b/GTFOHax/menu.cpp
@@ -886,46 +886,62 @@ void RenderWorldESP()
     RenderBulkheads();
 }
 
-void DrawBone(ImU32 color, app::Vector3 startBone, app::Vector3 endBone, float thickness)
+void DrawBone(ImU32 color, Enemy::EnemyInfo* info, app::HumanBodyBones__Enum startBone, app::HumanBodyBones__Enum endBone, float thickness)
 {
-    if (!G::mainCamera)
-        return;
+    int startIdx = static_cast<int>(startBone);
+    int endIdx = static_cast<int>(endBone);
+    
+    if (startIdx < 0 || startIdx >= 64 || endIdx < 0 || endIdx >= 64) return;
+    if (!info->hasBone[startIdx] || !info->hasBone[endIdx]) return;
+
     ImVec2 drawPosStart, drawPosEnd;
-    if (!Math::WorldToScreen(startBone, drawPosStart) || !Math::WorldToScreen(endBone, drawPosEnd))
-        return;
+    
+    if (info->screenPositionsValid[startIdx])
+        drawPosStart = info->screenPositions[startIdx];
+    else {
+        if (!Math::WorldToScreen(info->bones[startIdx].position, drawPosStart)) return;
+        info->screenPositions[startIdx] = drawPosStart;
+        info->screenPositionsValid[startIdx] = true;
+    }
+
+    if (info->screenPositionsValid[endIdx])
+        drawPosEnd = info->screenPositions[endIdx];
+    else {
+        if (!Math::WorldToScreen(info->bones[endIdx].position, drawPosEnd)) return;
+        info->screenPositions[endIdx] = drawPosEnd;
+        info->screenPositionsValid[endIdx] = true;
+    }
+
     ImGui::GetBackgroundDrawList()->AddLine(drawPosStart, drawPosEnd, color, thickness);
 }
 
 void DrawSkeleton(Enemy::EnemyInfo* fullInfo)
 {
-    for (std::vector<std::vector<app::HumanBodyBones__Enum>>::iterator itOuter = Enemy::skeletonBones.begin(); itOuter != Enemy::skeletonBones.end(); ++itOuter)
+    for (const auto& boneGroup : Enemy::skeletonBones)
     { 
-        Enemy::Bone prevBone;
-        for (std::vector<app::HumanBodyBones__Enum>::iterator it = (*itOuter).begin(); it != (*itOuter).end(); ++it)
+        app::HumanBodyBones__Enum prevBoneType = (app::HumanBodyBones__Enum)-1;
+        for (const auto& curBoneType : boneGroup)
         {
-            Enemy::Bone curBone = fullInfo->skeletonBones[*it]; // TODO: Fix map issue
-            if (prevBone.position.x == 0.0f && prevBone.position.y == 0.0f && prevBone.position.z == 0.0f)
+            if (prevBoneType == (app::HumanBodyBones__Enum)-1)
             {
-                prevBone = curBone;
+                prevBoneType = curBoneType;
                 continue;
             }
-            if (curBone.position.x == 0.0f && curBone.position.y == 0.0f && curBone.position.z == 0.0f)
-                continue;
             
-            if (prevBone.visible || curBone.visible)
+            const Enemy::Bone* prevBone = fullInfo->getBone(prevBoneType);
+            const Enemy::Bone* curBone = fullInfo->getBone(curBoneType);
+            
+            if (!prevBone || !curBone) continue;
+
+            bool isVisible = prevBone->visible || curBone->visible;
+            auto& espSec = isVisible ? ESP::enemyESP.visibleSec : ESP::enemyESP.nonVisibleSec;
+
+            if (espSec.showSkeleton && fullInfo->distance <= espSec.skeletonRenderDistance)
             {
-                if (!ESP::enemyESP.visibleSec.showSkeleton || fullInfo->distance > ESP::enemyESP.visibleSec.skeletonRenderDistance)
-                    continue;
-                DrawBone(ImGui::GetColorU32(ESP::enemyESP.visibleSec.skeletonColor), prevBone.position, curBone.position, ESP::enemyESP.visibleSec.skeletonThickness);
-            }
-            else
-            {
-                if (!ESP::enemyESP.nonVisibleSec.showSkeleton || fullInfo->distance > ESP::enemyESP.nonVisibleSec.skeletonRenderDistance)
-                    continue;
-                DrawBone(ImGui::GetColorU32(ESP::enemyESP.nonVisibleSec.skeletonColor), prevBone.position, curBone.position, ESP::enemyESP.nonVisibleSec.skeletonThickness);
+                DrawBone(ImGui::GetColorU32(espSec.skeletonColor), fullInfo, prevBoneType, curBoneType, espSec.skeletonThickness);
             }
 
-            prevBone = curBone;
+            prevBoneType = curBoneType;
         }
     }
 }
@@ -940,55 +956,47 @@ void RenderEnemyAgent(Enemy::EnemyInfo* enemyInfo, ESP::AgentESPSection* espSett
                           Aimbot::settings.toggleKey.isToggled() &&
                           Aimbot::IsLockedTarget(enemyInfo->enemyAgent);
 
-    Enemy::Bone headBone = enemyInfo->useFallback ? enemyInfo->fallbackBone : enemyInfo->skeletonBones[app::HumanBodyBones__Enum::Head]; // TODO: Fix map issue
+    const Enemy::Bone* headBone = enemyInfo->useFallback ? &enemyInfo->fallbackBone : enemyInfo->getBone(app::HumanBodyBones__Enum::Head);
+    if (!headBone) return;
+
     ImVec2 w2sHead;
-    if (!Math::WorldToScreen(headBone.position, w2sHead))
+    if (!Math::WorldToScreen(headBone->position, w2sHead))
         return;
 
-    ImVec2 w2sLeftFoot, w2sRightFoot;
-    if (!enemyInfo->useFallback)
-    {
-        Enemy::Bone leftFootBone = enemyInfo->skeletonBones[app::HumanBodyBones__Enum::LeftFoot]; // TODO: Fix map issue
-        Enemy::Bone rightFootBone = enemyInfo->skeletonBones[app::HumanBodyBones__Enum::RightFoot]; // TODO: Fix map issue
-        if (!Math::WorldToScreen(leftFootBone.position, w2sLeftFoot) ||
-            !Math::WorldToScreen(rightFootBone.position, w2sRightFoot))
-            return;
-    }
-    else
-    {
-        w2sLeftFoot = w2sRightFoot = w2sHead;
-    }
+    ImVec2 min = w2sHead, max = w2sHead;
+    bool valid = true;
     
-    ImVec2 min, max;
     if (!enemyInfo->useFallback)
     {
         min.y = min.x = (std::numeric_limits<float>::max)();
         max.y = max.x = -(std::numeric_limits<float>::max)();
-    }
-    else
-    {
-        min.x = max.x = w2sHead.x;
-        min.y = max.y = w2sHead.y;
-    }
-    bool valid = true;
-    for (auto const& [key, val] : enemyInfo->skeletonBones)
-    {
-        ImVec2 curPos;
-        auto bonePos = val.position;
-        if (!Math::WorldToScreen((bonePos), curPos))
+
+        int validBones = 0;
+        for (int i = 0; i < 64; i++)
         {
-            valid = false;
-            continue;
+            if (!enemyInfo->hasBone[i]) continue;
+            
+            ImVec2 curPos;
+            if (enemyInfo->screenPositionsValid[i])
+                curPos = enemyInfo->screenPositions[i];
+            else {
+                if (!Math::WorldToScreen(enemyInfo->bones[i].position, curPos)) {
+                    continue; // Skip this bone for bounding box, but keep the enemy
+                }
+                enemyInfo->screenPositions[i] = curPos;
+                enemyInfo->screenPositionsValid[i] = true;
+            }
+            min.x = (std::min)(min.x, curPos.x);
+            min.y = (std::min)(min.y, curPos.y);
+            max.x = (std::max)(max.x, curPos.x);
+            max.y = (std::max)(max.y, curPos.y);
+            validBones++;
         }
-        min.x = (std::min)(min.x, curPos.x);
-        min.y = (std::min)(min.y, curPos.y);
-        max.x = (std::max)(max.x, curPos.x);
-        max.y = (std::max)(max.y, curPos.y);
+        if (validBones == 0) valid = false;
     }
 
     if (espSettings->showBoxes && !enemyInfo->useFallback && valid)
     {    
-        // Use highlight color if this is the locked target
         ImU32 boxColor = isLockedTarget ? ImGui::GetColorU32(Aimbot::settings.targetHighlightColor) 
                                         : ImGui::GetColorU32(espSettings->boxesColor);
         ImU32 outlineColor = ImGui::GetColorU32(espSettings->boxesOutlineColor);
@@ -997,6 +1005,7 @@ void RenderEnemyAgent(Enemy::EnemyInfo* enemyInfo, ESP::AgentESPSection* espSett
         ImGui::GetBackgroundDrawList()->AddRect(ImVec2{ min.x + 1.0f, min.y + 1.0f }, ImVec2{ max.x - 1.0f, max.y - 1.0f }, outlineColor);
         ImGui::GetBackgroundDrawList()->AddRect(min, max, boxColor);
     }
+
 
 
     auto enemyDamage = reinterpret_cast<app::Dam_SyncedDamageBase*>(enemyInfo->enemyAgent->fields.Damage);
@@ -1110,23 +1119,25 @@ void RenderEnemyAgent(Enemy::EnemyInfo* enemyInfo, ESP::AgentESPSection* espSett
 
 void RenderEnemyESP()
 {
-    G::enemyVecMtx.lock();
-    std::vector<std::shared_ptr<Enemy::EnemyInfo>> enemies = Enemy::enemies;
-    G::enemyVecMtx.unlock();
-    std::sort(enemies.begin(), enemies.end(), [](const std::shared_ptr<Enemy::EnemyInfo> lhs, const std::shared_ptr<Enemy::EnemyInfo> rhs) {
+    auto enemiesSnap = Enemy::enemies.load();
+    if (!enemiesSnap || enemiesSnap->empty()) return;
+
+    // Use a temporary vector of pointers for sorting to avoid copying shared_ptrs
+    static std::vector<Enemy::EnemyInfo*> sortedEnemies;
+    sortedEnemies.clear();
+    sortedEnemies.reserve(enemiesSnap->size());
+
+    for (auto& enemy : *enemiesSnap)
+        sortedEnemies.push_back(enemy.get());
+
+    // Sorting by distance ensures enemies further away are drawn first (if we cared about transparency)
+    std::sort(sortedEnemies.begin(), sortedEnemies.end(), [](Enemy::EnemyInfo* lhs, Enemy::EnemyInfo* rhs) {
         return lhs->distance > rhs->distance;
-        });
-    for (auto it = enemies.begin(); it != enemies.end(); ++it)
+    });
+
+    for (auto enemyInfo : sortedEnemies)
     {
-        Enemy::EnemyInfo* enemyInfo = (*it).get();
-
-        Enemy::Bone defBone;
-        if (enemyInfo->useFallback)
-            defBone = enemyInfo->fallbackBone;
-        else
-            defBone = enemyInfo->skeletonBones[app::HumanBodyBones__Enum::Head]; // TODO: Fix map issue
-
-        if (!G::mainCamera || !(enemyInfo->enemyAgent->fields.m_alive) || (defBone.position.x == 0.0f && defBone.position.y == 0.0f && defBone.position.z == 0.0f))
+        if (!G::mainCamera || !(enemyInfo->enemyAgent->fields.m_alive))
             continue;
 
         if (enemyInfo->visible && ESP::enemyESP.visibleSec.show)
@@ -1165,6 +1176,11 @@ void RenderESP()
     {
         G::mainCamera = app::Camera_get_main(NULL);
         return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(G::matrixMtx);
+        G::renderViewMatrix = G::viewMatrix;
     }
 
     G::screenHeight = app::Screen_get_height(NULL);

--- a/GTFOHax/utils/math.cpp
+++ b/GTFOHax/utils/math.cpp
@@ -39,9 +39,9 @@ namespace Math
         return matrix4x4;
     }
 
-    bool WorldToScreen(app::Vector3& worldPos, ImVec2& screenPos)
+    bool WorldToScreen(const app::Vector3& worldPos, ImVec2& screenPos)
     {
-        auto matrix = G::viewMatrix;
+        auto matrix = G::renderViewMatrix;
         app::Vector3 screenPosTemp;
 
         screenPosTemp.z = (matrix.m20 * worldPos.x + matrix.m21 * worldPos.y + matrix.m22 * worldPos.z) + matrix.m23;
@@ -60,7 +60,7 @@ namespace Math
 
 
         screenPos.x = screenPosTemp.x;
-        screenPos.y = G::screenHeight - screenPosTemp.y;
+        screenPos.y = (float)G::screenHeight - screenPosTemp.y;
 
         //if (screenPos.x < 0 || screenPos.y < 0 || screenPos.x > G::screenWidth || screenPos.y > G::screenHeight)
         //    return false;

--- a/GTFOHax/utils/math.h
+++ b/GTFOHax/utils/math.h
@@ -12,5 +12,5 @@ namespace Math
     app::Vector3 Vector3Sub(app::Vector3 lhs, app::Vector3 rhs);
     bool Vector3Eq(app::Vector3 lhs, app::Vector3 rhs);
     app::Matrix4x4 MatrixMult(app::Matrix4x4 lhs, app::Matrix4x4 rhs);
-    bool WorldToScreen(app::Vector3& worldPos, ImVec2& screenPos);
+    bool WorldToScreen(const app::Vector3& worldPos, ImVec2& screenPos);
 }


### PR DESCRIPTION
Add enemy cache and improves loop speed ~3.5x.
Move most of enemy refresh to separate thread for further performance improvements.

With 300 enemies no noticeable fps drop is noticed unlike before which would drop me by 80fps when dealing with 300 enemies.