### PR TITLE
Fix duplicated full-width and IME input in chat

### DIFF
--- a/GTFOHax/hooks.cpp
+++ b/GTFOHax/hooks.cpp
@@ -1237,6 +1237,20 @@ void Hooks::hkPreLitVolume_Update(app::PreLitVolume* __this, MethodInfo* method)
 
 LRESULT __stdcall WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    const bool isTextInputMessage =
+        uMsg == WM_CHAR ||
+        uMsg == WM_SYSCHAR ||
+        uMsg == WM_DEADCHAR ||
+        uMsg == WM_SYSDEADCHAR ||
+        uMsg == WM_UNICHAR ||
+        uMsg == WM_IME_CHAR ||
+        uMsg == WM_IME_COMPOSITION ||
+        uMsg == WM_IME_STARTCOMPOSITION ||
+        uMsg == WM_IME_ENDCOMPOSITION;
+
+    if (!G::showMenu && isTextInputMessage)
+        return CallWindowProc(G::oWndProc, hWnd, uMsg, wParam, lParam);
+
     if (G::imguiMtx.try_lock())
     {
         ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam);


### PR DESCRIPTION
Full-width characters and committed IME input could be duplicated in chat when the overlay menu was hidden, because text and IME window messages were handled by both ImGui and the game here:

```
ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam);

if (G::showMenu)
    return TRUE;

return CallWindowProc(G::oWndProc, hWnd, uMsg, wParam, lParam);

```
I bypassed ImGui handling for text and IME messages while the overlay menu is hidden, forwarding them directly to the game window procedure instead. Keyboard and mouse messages continue to pass through ImGui so overlay hotkeys remain functional.