### PR TITLE
Fix missing world ESP after checkpoint restore

### DIFF
--- a/GTFOHax/hacks/esp.cpp
+++ b/GTFOHax/hacks/esp.cpp
@@ -1,4 +1,6 @@
 #include "esp.h"
+#include <algorithm>
+#include <atomic>
 
 namespace ESP
 {
@@ -19,6 +21,128 @@ namespace ESP
 
     std::vector<WorldBulkheadDC> worldBulkheadDCs;
     std::vector<WorldTerminalItem> worldTerminals;
+
+    static std::atomic_bool g_worldRescanRequested{true};
+
+    template <typename T, typename TValue>
+    static bool ContainsPtr(const std::vector<T>& items, TValue T::* member, TValue ptr)
+    {
+        return std::ranges::any_of(items, [member, ptr](const T& item) {
+            return item.*member == ptr;
+        });
+    }
+
+    static void AddTerminal(app::LG_ComputerTerminal* terminal)
+    {
+        if (!terminal || !app::Object_1_op_Implicit(reinterpret_cast<app::Object_1*>(terminal), nullptr))
+            return;
+
+        std::lock_guard<std::mutex> lock(G::worldTerminalsMtx);
+        if (!ContainsPtr(worldTerminals, &WorldTerminalItem::terminalItem, terminal))
+            worldTerminals.push_back(WorldTerminalItem(terminal));
+    }
+
+    static void AddCarryItem(app::CarryItemPickup_Core* carryItem)
+    {
+        if (!carryItem || !app::Object_1_op_Implicit(reinterpret_cast<app::Object_1*>(carryItem), nullptr))
+            return;
+        if (!carryItem->fields.m_sync)
+            return;
+
+        std::lock_guard<std::mutex> lock(G::worldCarryMtx);
+        if (!ContainsPtr(worldCarryItems, &WorldCarryItem::carryItem, carryItem))
+            worldCarryItems.push_back(WorldCarryItem(carryItem));
+    }
+
+    static bool TerminalCacheEmpty()
+    {
+        std::lock_guard<std::mutex> lock(G::worldTerminalsMtx);
+        return worldTerminals.empty();
+    }
+
+    static bool CarryItemCacheEmpty()
+    {
+        std::lock_guard<std::mutex> lock(G::worldCarryMtx);
+        return worldCarryItems.empty();
+    }
+
+    static void RescanTerminalsFromManager()
+    {
+        if (!app::LG_ComputerTerminalManager__TypeInfo || !*app::LG_ComputerTerminalManager__TypeInfo)
+            return;
+
+        auto manager = (*app::LG_ComputerTerminalManager__TypeInfo)->static_fields->Current;
+        if (!manager || !manager->fields.m_terminals || !manager->fields.m_terminals->fields.entries)
+            return;
+
+        auto entries = manager->fields.m_terminals->fields.entries;
+        const int count = (std::min)(manager->fields.m_terminals->fields.count, static_cast<int>(entries->max_length));
+        for (int i = 0; i < count; ++i)
+        {
+            const auto& entry = entries->vector[i];
+            if (entry.hashCode < 0 || !entry.value)
+                continue;
+            AddTerminal(entry.value);
+        }
+    }
+
+    static void RescanCourseNodeMetadata(bool needsTerminals, bool needsCarryItems)
+    {
+        if (!app::StaticUpdateManager__TypeInfo || !*app::StaticUpdateManager__TypeInfo)
+            return;
+
+        auto courseNodesList = (*app::StaticUpdateManager__TypeInfo)->static_fields->courseNodes;
+        if (!courseNodesList || !courseNodesList->fields._items)
+            return;
+
+        const int nodeCount = (std::min)(courseNodesList->fields._size, static_cast<int>(courseNodesList->fields._items->max_length));
+        for (int i = 0; i < nodeCount; ++i)
+        {
+            auto courseNode = courseNodesList->fields._items->vector[i];
+            if (!courseNode || !courseNode->fields.MetaData)
+                continue;
+
+            auto terminals = courseNode->fields.MetaData->fields.ComputerTerminals;
+            if (needsTerminals && terminals && terminals->fields._items)
+            {
+                const int terminalCount = (std::min)(terminals->fields._size, static_cast<int>(terminals->fields._items->max_length));
+                for (int j = 0; j < terminalCount; ++j)
+                    AddTerminal(terminals->fields._items->vector[j]);
+            }
+
+            auto carryItems = courseNode->fields.MetaData->fields.MissionPickupItems;
+            if (needsCarryItems && carryItems && carryItems->fields._items)
+            {
+                const int carryCount = (std::min)(carryItems->fields._size, static_cast<int>(carryItems->fields._items->max_length));
+                for (int j = 0; j < carryCount; ++j)
+                    AddCarryItem(carryItems->fields._items->vector[j]);
+            }
+        }
+    }
+
+    void RequestWorldRescan()
+    {
+        g_worldRescanRequested.store(true, std::memory_order_relaxed);
+    }
+
+    void RescanWorldIfNeeded()
+    {
+        if (!g_worldRescanRequested.exchange(false, std::memory_order_relaxed))
+            return;
+        if (app::GameStateManager_get_CurrentStateName(nullptr) != app::eGameStateName__Enum::InLevel)
+        {
+            RequestWorldRescan();
+            return;
+        }
+        const bool needsTerminals = TerminalCacheEmpty();
+        const bool needsCarryItems = CarryItemCacheEmpty();
+        if (!needsTerminals && !needsCarryItems)
+            return;
+
+        if (needsTerminals)
+            RescanTerminalsFromManager();
+        RescanCourseNodeMetadata(needsTerminals, needsCarryItems);
+    }
 
     void Init()
     {

--- a/GTFOHax/hacks/esp.h
+++ b/GTFOHax/hacks/esp.h
@@ -345,4 +345,6 @@ namespace ESP
 
     void Init();
     void UpdateInput();
+    void RequestWorldRescan();
+    void RescanWorldIfNeeded();
 }

--- a/GTFOHax/hooks.cpp
+++ b/GTFOHax/hooks.cpp
@@ -878,6 +878,8 @@ void Hooks::hkGameStateManager_ChangeState(app::eGameStateName__Enum nextState, 
         ESP::worldBulkheadDCs.clear();
         G::worldBulkheadMtx.unlock();
     }
+
+    ESP::RequestWorldRescan();
 }
 
 void Hooks::hkApplication_Quit(int32_t exitCode, MethodInfo* method)

--- a/GTFOHax/menu.cpp
+++ b/GTFOHax/menu.cpp
@@ -1185,7 +1185,10 @@ void RenderESP()
     if (ESP::enemyESP.toggleKey.isToggled())
         RenderEnemyESP();
     if (ESP::worldESPToggleKey.isToggled())
+    {
+        ESP::RescanWorldIfNeeded();
         RenderWorldESP();
+    }
     if (Aimbot::settings.toggleKey.isToggled())
     {
         RenderAimbotESP();


### PR DESCRIPTION
For now, world ESP could fail to render after restarting from a checkpoint. I tried to rescan supported world ESP data from `StaticUpdateManager.courseNodes` metadata and `LG_ComputerTerminalManager` state.

For now, the rescan is intentionally limited to computer terminals and mission carry items. A full world-object rescan was avoided because it can occasionally crash the game, likely when some objects have not been fully registered or initialized yet. This keeps the fix conservative and only restores categories backed by stable game-maintained lists.

This change also adds `<algorithm>` and `<atomic>`. The expected overhead should be minimal, but the performance impact has not been deeply profiled. Please commit if there's any performance drop :)