### PR TITLE
Fix world ESP data getting cleared on checkpoint restart

### DIFF
--- a/GTFOHax/hacks/esp.h
+++ b/GTFOHax/hacks/esp.h
@@ -56,6 +56,14 @@ namespace ESP
         ImVec4 outlineColor = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
     };
 
+    // True while the wrapped Unity object is still alive (op_Implicit also catches
+    // destroyed-but-not-yet-GC'd objects), checked before we dereference it in update().
+    template <typename T>
+    inline bool IsUnityObjectAlive(T* obj)
+    {
+        return obj && app::Object_1_op_Implicit(reinterpret_cast<app::Object_1*>(obj), NULL);
+    }
+
     struct WorldPickupItem
     {
         app::LG_PickupItem_Sync* pickupItem;
@@ -72,6 +80,11 @@ namespace ESP
         {
             this->state = app::LG_PickupItem_Sync_GetCurrentState(this->pickupItem, NULL);
             this->distance = app::Vector3_Distance(this->state.placement.position, G::localPlayer->fields.m_goodPosition, NULL);
+        }
+
+        bool alive() const
+        {
+            return IsUnityObjectAlive(pickupItem);
         }
 
         bool operator>(const WorldPickupItem& rhs) const
@@ -100,6 +113,11 @@ namespace ESP
             this->distance = app::Vector3_Distance(this->state.placement.position, G::localPlayer->fields.m_goodPosition, NULL);
         }
 
+        bool alive() const
+        {
+            return IsUnityObjectAlive(artifactItem) && artifactItem->fields.m_sync;
+        }
+
         bool operator>(const WorldArtifactItem& rhs) const
         {
             return this->distance > rhs.distance;
@@ -124,6 +142,11 @@ namespace ESP
             this->pickupItem = reinterpret_cast<app::LG_PickupItem_Sync*>(carryItem->fields.m_sync);
             this->state = app::LG_PickupItem_Sync_GetCurrentState(this->pickupItem, NULL);
             this->distance = app::Vector3_Distance(this->state.placement.position, G::localPlayer->fields.m_goodPosition, NULL);
+        }
+
+        bool alive() const
+        {
+            return IsUnityObjectAlive(carryItem) && carryItem->fields.m_sync;
         }
 
         bool operator>(const WorldCarryItem& rhs) const
@@ -152,6 +175,11 @@ namespace ESP
             this->distance = app::Vector3_Distance(this->state.placement.position, G::localPlayer->fields.m_goodPosition, NULL);
         }
 
+        bool alive() const
+        {
+            return IsUnityObjectAlive(keyItem) && keyItem->fields.m_sync;
+        }
+
         bool operator>(const WorldKeyItem& rhs) const
         {
             return this->distance > rhs.distance;
@@ -176,6 +204,11 @@ namespace ESP
             this->pickupItem = reinterpret_cast<app::LG_PickupItem_Sync*>(genericItem->fields.m_sync);
             this->state = app::LG_PickupItem_Sync_GetCurrentState(this->pickupItem, NULL);
             this->distance = app::Vector3_Distance(this->state.placement.position, G::localPlayer->fields.m_goodPosition, NULL);
+        }
+
+        bool alive() const
+        {
+            return IsUnityObjectAlive(genericItem) && genericItem->fields.m_sync;
         }
 
         bool operator>(const WorldGenericItem& rhs) const
@@ -204,6 +237,11 @@ namespace ESP
             this->distance = app::Vector3_Distance(this->state.placement.position, G::localPlayer->fields.m_goodPosition, NULL);
         }
 
+        bool alive() const
+        {
+            return IsUnityObjectAlive(resourceItem) && resourceItem->fields.m_sync;
+        }
+
         bool operator>(const WorldResourceItem& rhs) const
         {
             return this->distance > rhs.distance;
@@ -224,6 +262,11 @@ namespace ESP
         void update()
         {
             this->distance = app::Vector3_Distance(terminalItem->fields.m_position, G::localPlayer->fields.m_goodPosition, NULL);
+        }
+
+        bool alive() const
+        {
+            return IsUnityObjectAlive(terminalItem);
         }
 
         bool operator>(const WorldTerminalItem& rhs) const
@@ -251,6 +294,11 @@ namespace ESP
             this->distance = app::Vector3_Distance(this->position, G::localPlayer->fields.m_goodPosition, NULL);
         }
 
+        bool alive() const
+        {
+            return IsUnityObjectAlive(hsuItem) && hsuItem->fields.m_terminalItem;
+        }
+
         bool operator>(const WorldHSUItem& rhs) const
         {
             return this->distance > rhs.distance;
@@ -274,6 +322,11 @@ namespace ESP
             this->terminalItem = reinterpret_cast<app::LG_GenericTerminalItem*>(bulkheadDC->fields.m_terminalItem);
             this->position = app::LG_GenericTerminalItem_get_LocatorBeaconPosition(this->terminalItem, NULL);
             this->distance = app::Vector3_Distance(this->position, G::localPlayer->fields.m_goodPosition, NULL);
+        }
+
+        bool alive() const
+        {
+            return IsUnityObjectAlive(bulkheadDC) && bulkheadDC->fields.m_terminalItem;
         }
 
         bool operator>(const WorldBulkheadDC& rhs) const

--- a/GTFOHax/hooks.cpp
+++ b/GTFOHax/hooks.cpp
@@ -840,43 +840,54 @@ void Hooks::hkGameStateManager_ChangeState(app::eGameStateName__Enum nextState, 
 
     if (nextState < app::eGameStateName__Enum::Generating || nextState > app::eGameStateName__Enum::InLevel)
     {
+         // The camera is rebuilt on a reload, so always drop and re-acquire it
         G::mainCamera = NULL;
 
-        G::worldItemsMtx.lock();
-        ESP::worldItems.clear();
-        G::worldItemsMtx.unlock();
+        // But don't clear our level-object caches on a checkpoint reload (death goes
+        // InLevel -> ExpeditionFail -> InLevel; CaptureRecall is the drop-in path). A reload
+        // restores objects in place, so cached pointers stay valid and *_Setup never re-fires to
+        // refill us, so clearing here would leave ESP empty until a full restart. A real exit to
+        // the lobby still clears, since that transition is < Generating.
+        if (nextState != app::eGameStateName__Enum::CaptureRecall
+            && nextState != app::eGameStateName__Enum::ExpeditionFail)
+        {
 
-        G::worldArtifMtx.lock();
-        ESP::worldArtifacts.clear();
-        G::worldArtifMtx.unlock();
+            G::worldItemsMtx.lock();
+            ESP::worldItems.clear();
+            G::worldItemsMtx.unlock();
 
-        G::worldCarryMtx.lock();
-        ESP::worldCarryItems.clear();
-        G::worldCarryMtx.unlock();
-        
-        G::worldKeyMtx.lock();
-        ESP::worldKeys.clear();
-        G::worldKeyMtx.unlock();
-        
-        G::worldGenericMtx.lock();
-        ESP::worldGenerics.clear();
-        G::worldGenericMtx.unlock();
-        
-        G::worldResourcePackMtx.lock();
-        ESP::worldResourcePacks.clear();
-        G::worldResourcePackMtx.unlock();
-        
-        G::worldTerminalsMtx.lock();
-        ESP::worldTerminals.clear();
-        G::worldTerminalsMtx.unlock();
+            G::worldArtifMtx.lock();
+            ESP::worldArtifacts.clear();
+            G::worldArtifMtx.unlock();
 
-        G::worldHSUMtx.lock();
-        ESP::worldHSUItems.clear();
-        G::worldHSUMtx.unlock();
+            G::worldCarryMtx.lock();
+            ESP::worldCarryItems.clear();
+            G::worldCarryMtx.unlock();
 
-        G::worldBulkheadMtx.lock();
-        ESP::worldBulkheadDCs.clear();
-        G::worldBulkheadMtx.unlock();
+            G::worldKeyMtx.lock();
+            ESP::worldKeys.clear();
+            G::worldKeyMtx.unlock();
+
+            G::worldGenericMtx.lock();
+            ESP::worldGenerics.clear();
+            G::worldGenericMtx.unlock();
+
+            G::worldResourcePackMtx.lock();
+            ESP::worldResourcePacks.clear();
+            G::worldResourcePackMtx.unlock();
+
+            G::worldTerminalsMtx.lock();
+            ESP::worldTerminals.clear();
+            G::worldTerminalsMtx.unlock();
+
+            G::worldHSUMtx.lock();
+            ESP::worldHSUItems.clear();
+            G::worldHSUMtx.unlock();
+
+            G::worldBulkheadMtx.lock();
+            ESP::worldBulkheadDCs.clear();
+            G::worldBulkheadMtx.unlock();
+        }
     }
 }
 
@@ -928,6 +939,17 @@ void Hooks::hkCursor_set_visible(bool value, MethodInfo* method)
 {
     static auto fpOFunc = reinterpret_cast<void (*)(bool, MethodInfo*)>(hooks["Cursor_set_visible"]);
     fpOFunc(G::showMenu, method);
+}
+
+// Drop dead entries (destroyed objects, e.g. picked up or gone after a reload), refresh
+// distances on the survivors, then sort far-to-near.
+template <typename T>
+static void RefreshWorldVec(std::vector<T>& vec, std::mutex& mtx)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    std::erase_if(vec, [](const T& item) { return !item.alive(); });
+    for (T& item : vec) item.update();
+    std::sort(vec.begin(), vec.end(), std::greater<T>());
 }
 
 void Hooks::hkLocalPlayerAgent_Update(app::LocalPlayerAgent* __this, MethodInfo* method)
@@ -1034,50 +1056,15 @@ void Hooks::hkLocalPlayerAgent_Update(app::LocalPlayerAgent* __this, MethodInfo*
         fullBrightLight = nullptr;
     }
 
-    G::worldItemsMtx.lock();
-    for (ESP::WorldPickupItem& i : ESP::worldItems) i.update();
-    std::sort(ESP::worldItems.begin(), ESP::worldItems.end(), std::greater<ESP::WorldPickupItem>());
-    G::worldItemsMtx.unlock();
-
-    G::worldArtifMtx.lock();
-    for (ESP::WorldArtifactItem& i : ESP::worldArtifacts) i.update();
-    std::sort(ESP::worldArtifacts.begin(), ESP::worldArtifacts.end(), std::greater<ESP::WorldArtifactItem>());
-    G::worldArtifMtx.unlock();
-
-    G::worldCarryMtx.lock();
-    for (ESP::WorldCarryItem& i : ESP::worldCarryItems) i.update();
-    std::sort(ESP::worldCarryItems.begin(), ESP::worldCarryItems.end(), std::greater<ESP::WorldCarryItem>());
-    G::worldCarryMtx.unlock();
-    
-    G::worldKeyMtx.lock();
-    for (ESP::WorldKeyItem& i : ESP::worldKeys) i.update();
-    std::sort(ESP::worldKeys.begin(), ESP::worldKeys.end(), std::greater<ESP::WorldKeyItem>());
-    G::worldKeyMtx.unlock();
-    
-    G::worldGenericMtx.lock();
-    for (ESP::WorldGenericItem& i : ESP::worldGenerics) i.update();
-    std::sort(ESP::worldGenerics.begin(), ESP::worldGenerics.end(), std::greater<ESP::WorldGenericItem>());
-    G::worldGenericMtx.unlock();
-    
-    G::worldResourcePackMtx.lock();
-    for (ESP::WorldResourceItem& i : ESP::worldResourcePacks) i.update();
-    std::sort(ESP::worldResourcePacks.begin(), ESP::worldResourcePacks.end(), std::greater<ESP::WorldResourceItem>());
-    G::worldResourcePackMtx.unlock();
-    
-    G::worldTerminalsMtx.lock();
-    for (ESP::WorldTerminalItem& i : ESP::worldTerminals) i.update();
-    std::sort(ESP::worldTerminals.begin(), ESP::worldTerminals.end(), std::greater<ESP::WorldTerminalItem>());
-    G::worldTerminalsMtx.unlock();
-
-    G::worldHSUMtx.lock();
-    for (ESP::WorldHSUItem& i : ESP::worldHSUItems) i.update();
-    std::sort(ESP::worldHSUItems.begin(), ESP::worldHSUItems.end(), std::greater<ESP::WorldHSUItem>());
-    G::worldHSUMtx.unlock();
-
-    G::worldBulkheadMtx.lock();
-    for (ESP::WorldBulkheadDC& i : ESP::worldBulkheadDCs) i.update();
-    std::sort(ESP::worldBulkheadDCs.begin(), ESP::worldBulkheadDCs.end(), std::greater<ESP::WorldBulkheadDC>());
-    G::worldBulkheadMtx.unlock();
+    RefreshWorldVec(ESP::worldItems, G::worldItemsMtx);
+    RefreshWorldVec(ESP::worldArtifacts, G::worldArtifMtx);
+    RefreshWorldVec(ESP::worldCarryItems, G::worldCarryMtx);
+    RefreshWorldVec(ESP::worldKeys, G::worldKeyMtx);
+    RefreshWorldVec(ESP::worldGenerics, G::worldGenericMtx);
+    RefreshWorldVec(ESP::worldResourcePacks, G::worldResourcePackMtx);
+    RefreshWorldVec(ESP::worldTerminals, G::worldTerminalsMtx);
+    RefreshWorldVec(ESP::worldHSUItems, G::worldHSUMtx);
+    RefreshWorldVec(ESP::worldBulkheadDCs, G::worldBulkheadMtx);
 
     Aimbot::RunAimbot();
 }

--- a/GTFOHax/menu.cpp
+++ b/GTFOHax/menu.cpp
@@ -1168,7 +1168,9 @@ void RenderESP()
     if (!G::localPlayer)
         return;
 
-    if (G::mainCamera == NULL)
+    // Re-acquire if null or destroyed - the camera is rebuilt on a checkpoint reload, and a
+    // stale non-null pointer would crash the render path.
+    if (G::mainCamera == NULL || !app::Object_1_op_Implicit(reinterpret_cast<app::Object_1*>(G::mainCamera), NULL))
     {
         G::mainCamera = app::Camera_get_main(NULL);
         return;


### PR DESCRIPTION
Fixes world ESP getting cleared on checkpoint restart by only clearing if game state changes isn't an expedition fail or checkpoint restart. Doing that introduced some crashes so `IsUnityObjectAlive` was added to check if ESP items are still valid in a new template `RefreshWorldVec` which also cleans up the update calls for world ESP items.

@FridayAnubis I tested it a bit, so if possible try it out and let me know how it works for you.

This PR supersedes #16 since the game doesn't regenerate world items on a checkpoint reload so it's best to just not clear them in the first place.